### PR TITLE
fix: make plugin load on OpenCode 1.4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.4.0"
   },
+  "devDependencies": {
+    "@opencode-ai/plugin": "^1.4.0"
+  },
   "bin": {
     "opencode-loop": "./scripts/install-node.mjs",
     "opencode-loopd": "./scripts/loopd.mjs"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs"
 import path from "node:path"
 import { spawn } from "node:child_process"
+import { tool } from "@opencode-ai/plugin/tool"
 
 const SERVICE = "opencode-loop"
 const STATE_DIR = ".opencode/opencode-loop"
@@ -390,8 +391,8 @@ async function executeTuiCommand(client, command) {
   if (!client?.tui?.executeCommand) throw new Error("client.tui.executeCommand is not available")
   return await sdkCall(
     client.tui.executeCommand.bind(client.tui),
-    { command },
     { body: { command } },
+    { command },
   )
 }
 
@@ -415,7 +416,7 @@ async function compactSession(client, sessionID) {
     }
   }
   try {
-    await sdkCall(client.session.summarize.bind(client.session), { sessionID }, { path: { id: sessionID }, body: {} })
+    await sdkCall(client.session.summarize.bind(client.session), { path: { id: sessionID }, body: {} }, { sessionID })
     return true
   } catch (error) {
     await log(client, "warn", "session.summarize fallback failed", { error: sdkErrorMessage(error) })
@@ -428,22 +429,22 @@ async function log(client, level, message, extra) {
   try {
     await sdkCall(
       client.app.log.bind(client.app),
-      extra === undefined ? { service: SERVICE, level, message } : { service: SERVICE, level, message, extra },
       { body: extra === undefined ? { service: SERVICE, level, message } : { service: SERVICE, level, message, extra } },
+      { service: SERVICE, level, message, extra },
     )
   } catch {}
 }
 
 async function toast(client, message, variant = "info") {
-  try { await sdkCall(client.tui.showToast.bind(client.tui), { message, variant }, { body: { message, variant } }) } catch {}
+  try { await sdkCall(client.tui.showToast.bind(client.tui), { body: { message, variant } }, { message, variant }) } catch {}
 }
 
 async function say(client, sessionID, text) {
   try {
     await sdkCall(
       client.session.prompt.bind(client.session),
-      { sessionID, noReply: true, parts: [{ type: "text", text }] },
       { path: { id: sessionID }, body: { noReply: true, parts: [{ type: "text", text }] } },
+      { sessionID, noReply: true, parts: [{ type: "text", text }] },
     )
   } catch {}
 }
@@ -809,7 +810,7 @@ function staleActiveRun(sessionID) {
 
 async function readLiveSessionStatus(client, sessionID, directory) {
   const argsList = []
-  if (directory) argsList.push({ workspace: directory }, { directory })
+  if (directory) argsList.push({ query: { directory } }, { directory })
   argsList.push({})
   for (const args of argsList) {
     try {
@@ -1140,7 +1141,7 @@ async function finalizeActiveRun(directory, client, sessionID) {
   if (!active) return
   clearActiveRun(sessionID)
   const state = await readState(directory, sessionID)
-  const job = (state.jobs || []).find((candidate) => candidate.id === active.jobId)
+  let job = (state.jobs || []).find((candidate) => candidate.id === active.jobId)
   if (!job) return
   job.lastFinishedAt = now()
 
@@ -1209,7 +1210,7 @@ async function fireAction(directory, client, sessionID, job) {
       await compactSession(client, sessionID)
       return { startsAssistantTurn: true }
     }
-    await sdkCall(client.session.command.bind(client.session), { sessionID, command, arguments: argumentsText }, { path: { id: sessionID }, body: { command, arguments: argumentsText } })
+    await sdkCall(client.session.command.bind(client.session), { path: { id: sessionID }, body: { command, arguments: argumentsText } }, { sessionID, command, arguments: argumentsText })
     return { startsAssistantTurn: true }
   }
   if (kind === "shell") {
@@ -1219,18 +1220,18 @@ async function fireAction(directory, client, sessionID, job) {
       await appendLoopLog(directory, "blocked", { sessionID, job: job.name || job.id, command })
       return { startsAssistantTurn: false }
     }
-    fireSdk(client, "session.shell", client.session.shell.bind(client.session), { sessionID, command }, { path: { id: sessionID }, body: { command } })
+    fireSdk(client, "session.shell", client.session.shell.bind(client.session), { path: { id: sessionID }, body: { command } }, { sessionID, command })
     return { startsAssistantTurn: true }
   }
   const prompt = await buildPrompt(directory, job)
   const prefix = kind === "goal"
     ? "EXPERIMENTAL GOAL MODE CONTINUATION. Continue pursuing the active goal. Do not explain the /loop-goal command. Use the goal tools only when progress/completion/block state is real."
     : "AUTONOMOUS OPENCODE LOOP ITERATION. Continue the configured task now. Do not explain the /loop command. Do not search for documentation about this plugin. Do not create scheduler files. Do not ask questions. Make reasonable assumptions and work directly."
-  fireSdk(client, "session.prompt", client.session.prompt.bind(client.session), { sessionID, parts: [{ type: "text", text: `${prefix}
+  fireSdk(client, "session.prompt", client.session.prompt.bind(client.session), { path: { id: sessionID }, body: { parts: [{ type: "text", text: `${prefix}
 
-${prompt}` }] }, { path: { id: sessionID }, body: { parts: [{ type: "text", text: `${prefix}
+${prompt}` }] } }, { sessionID, parts: [{ type: "text", text: `${prefix}
 
-${prompt}` }] } })
+${prompt}` }] })
   return { startsAssistantTurn: true }
 }
 
@@ -1346,7 +1347,7 @@ async function maybeRunDueJobs(directory, client, sessionID, options = {}) {
         return
       }
       let timer
-      if (job.timeoutMs > 0) timer = setTimeout(() => { fireSdk(client, "session.abort", client.session.abort.bind(client.session), { sessionID }, { path: { id: sessionID }, body: {} }); toast(client, `Loop timeout fired: ${job.name || job.id}`, "warning").catch(() => {}) }, job.timeoutMs)
+      if (job.timeoutMs > 0) timer = setTimeout(() => { fireSdk(client, "session.abort", client.session.abort.bind(client.session), { path: { id: sessionID }, body: {} }, { sessionID }); toast(client, `Loop timeout fired: ${job.name || job.id}`, "warning").catch(() => {}) }, job.timeoutMs)
       activeRuns.set(sessionID, { jobId: job.id, job, startedAt: now(), timer })
       await reschedule(BUSY_RETRY_MS)
     } catch (error) {
@@ -1628,39 +1629,39 @@ async function handleCommand(directory, client, input, fallbackName, fallbackArg
 
 function goalTools(defaultDirectory) {
   return {
-    opencode_loop_goal_complete: {
+    opencode_loop_goal_complete: tool({
       description: "Mark the current OpenCode Loop experimental goal as completed. Use only after acceptance criteria are satisfied and you have evidence from tests, typecheck, build, or code inspection.",
       args: {
-        summary: { type: "string", description: "Short human-readable summary of what was completed." },
-        evidence: { type: "string", description: "Concrete evidence that the goal is complete, such as commands run, passing checks, files changed, and important results." },
+        summary: tool.schema.string().describe("Short human-readable summary of what was completed."),
+        evidence: tool.schema.string().describe("Concrete evidence that the goal is complete, such as commands run, passing checks, files changed, and important results."),
       },
       execute: async (args, context) => {
         const result = await setGoalComplete(context.directory || defaultDirectory, context.sessionID, args)
         return { title: result.ok ? "Goal completed" : "Goal not found", output: result.message }
       },
-    },
-    opencode_loop_goal_blocked: {
+    }),
+    opencode_loop_goal_blocked: tool({
       description: "Mark the current OpenCode Loop experimental goal as blocked when user input or manual intervention is required.",
       args: {
-        reason: { type: "string", description: "Why the goal is blocked." },
-        needed: { type: "string", description: "What user input, credential, decision, or manual action is needed to continue." },
+        reason: tool.schema.string().describe("Why the goal is blocked."),
+        needed: tool.schema.string().describe("What user input, credential, decision, or manual action is needed to continue."),
       },
       execute: async (args, context) => {
         const result = await setGoalBlocked(context.directory || defaultDirectory, context.sessionID, args)
         return { title: result.ok ? "Goal blocked" : "Goal not found", output: result.message }
       },
-    },
-    opencode_loop_goal_progress: {
+    }),
+    opencode_loop_goal_progress: tool({
       description: "Record meaningful progress on the current OpenCode Loop experimental goal without completing it.",
       args: {
-        summary: { type: "string", description: "What useful progress was made." },
-        next: { type: "string", description: "The next step toward completing the goal." },
+        summary: tool.schema.string().describe("What useful progress was made."),
+        next: tool.schema.string().describe("The next step toward completing the goal."),
       },
       execute: async (args, context) => {
         const result = await setGoalProgress(context.directory || defaultDirectory, context.sessionID, args)
         return { title: result.ok ? "Goal progress" : "Goal not found", output: result.message }
       },
-    },
+    }),
   }
 }
 


### PR DESCRIPTION
The plugin throws errors when loaded by current OpenCode builds. This fixes the four things causing them.

The three goal tools (`opencode_loop_goal_complete`, `opencode_loop_goal_blocked`, `opencode_loop_goal_progress`) were defined as plain objects with JSON-Schema-style args. OpenCode 1.4+ needs tools built with `tool()` from `@opencode-ai/plugin/tool` so the args become a ZodRawShape. Without that, the agent's tool calls fail validation.

`finalizeActiveRun` declared `const job` at the top but reassigned it later when running goal checks. Throws at runtime any time a goal job is finalized.

Every `sdkCall` to `client.app.log`, `client.session.*`, and `client.tui.*` was passing the modern arg shape as `{ sessionID, ... }` (top-level sessionID) while the correct shape is `{ path: { id: sessionID }, body: { ... } }`. The first attempt always failed and fell back. Swapped the order so the correct one runs first.

`readLiveSessionStatus` was passing `directory` as a top-level field. The SDK expects `{ query: { directory } }`. Added that as the first option.

While I was in there, also added `@opencode-ai/plugin` to devDependencies. The peerDependency stays for end users; this is so a fresh clone plus `npm install` has a working setup.

Tested by symlinking `~/.config/opencode/plugins/opencode-loop.js` to `src/index.js`. Loads cleanly, all three tools have Zod args, preset commands like `/loop-help` and `/loop-status` are handled, and unknown commands return false as expected.