### PR TITLE
docs: make Goal Mode a headline workflow

### DIFF
--- a/.github/workflows/apply-goal-mode-docs.yml
+++ b/.github/workflows/apply-goal-mode-docs.yml
@@ -1,0 +1,100 @@
+name: Apply Goal Mode docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Promote Goal Mode in README
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('README.md')
+          text = path.read_text()
+
+          def replace_once(old, new):
+              global text
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f'expected one README match, found {count}: {old[:100]!r}')
+              text = text.replace(old, new, 1)
+
+          replace_once(
+              '''**Claude Code style auto-continue for OpenCode.**
+
+OpenCode Loop adds a practical `/loop` command and `opencode-loopd` daemon to OpenCode so an agent can keep working after each idle turn instead of waiting for you to type “continue” again.
+''',
+              '''**Claude Code style auto-continue + persistent Goal Mode for OpenCode.**
+
+OpenCode Loop adds a practical `/loop` command and `opencode-loopd` daemon to OpenCode so an agent can keep working after each idle turn instead of waiting for you to type “continue” again. It also includes experimental `/loop-goal` for outcome-driven work that keeps pursuing a goal across idle turns until it is proven complete, blocked, paused, or stopped by safety limits.
+''',
+          )
+
+          replace_once(
+              '''Repository: **ByBrawe/opencode-loop**  
+NPM package name: **@bybrawe/opencode-loop**
+
+### Scheduler heartbeat note
+''',
+              '''Repository: **ByBrawe/opencode-loop**  
+NPM package name: **@bybrawe/opencode-loop**
+
+## Goal Mode: pursue an outcome, not a timer
+
+Normal loops answer “what should run again?” **Goal Mode answers “what result should the agent keep pursuing until it is actually done?”**
+
+```text
+/loop-goal --check "npm test" --complete-when-checks-pass fix the failing tests without weakening coverage
+```
+
+Goal Mode is experimental, but it is designed as a first-class workflow:
+
+- **Persistent objective:** the goal survives across idle turns instead of relying on a fixed timer.
+- **Evidence-gated completion:** the agent cannot finish with a generic “done”; completion needs concrete evidence.
+- **Verification gates:** `--check`, acceptance criteria, and `--complete-when-checks-pass` can define what “finished” means.
+- **Safety against runaway work:** user interruption, no-progress guards, max turns, and max runtime can pause or stop the goal.
+- **Inspectable progress:** Goal Mode records progress/evidence and can write a goal report under `.opencode/opencode-loop/goals/`.
+
+Use `/loop` for recurring or timer-driven work. Use `/loop-goal` when you care about an **outcome** and want OpenCode to keep working toward it until the result is verified or genuinely blocked.
+
+See [Goal Mode: persistent objectives](#goal-mode-persistent-objectives) for the full command guide and examples.
+
+### Scheduler heartbeat note
+''',
+          )
+
+          replace_once('### The 6 examples most people need', '### The examples most people need')
+          replace_once('### Experimental Goal Mode', '### Goal Mode: persistent objectives')
+          replace_once(
+              '- **Experimental Goal Mode** with `/loop-goal`, goal status, goal tools, acceptance criteria, and verification checks.\n',
+              '- **Experimental Goal Mode** with persistent objectives, evidence-gated completion, acceptance criteria, verification checks, no-progress guards, and goal reports.\n',
+          )
+          replace_once(
+              '- OpenCode auto continue\n- OpenCode continue automatically\n',
+              '- OpenCode auto continue\n- OpenCode Goal Mode\n- OpenCode persistent goal\n- Codex `/goal` style workflow for OpenCode\n- OpenCode continue automatically\n',
+          )
+
+          path.write_text(text)
+          PY
+
+      - name: Commit docs and remove one-shot workflow
+        shell: bash
+        run: |
+          rm .github/workflows/apply-goal-mode-docs.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md .github/workflows/apply-goal-mode-docs.yml
+          git commit -m "docs: make Goal Mode a headline workflow"
+          git push origin HEAD:main


### PR DESCRIPTION
## Goal

Make Goal Mode visible in the first screen of the project instead of burying its strongest explanation deep in the README.

## What the one-shot workflow will do after merge

- change the tagline to highlight both auto-continue and persistent Goal Mode;
- add a top-level “Goal Mode: pursue an outcome, not a timer” section with a check-gated example;
- explain persistent objectives, evidence-gated completion, verification gates, runaway-work safeguards, and goal reports;
- distinguish timer-driven `/loop` from outcome-driven `/loop-goal`;
- rename the detailed Goal Mode heading so the top section can link directly to it;
- improve Goal Mode search/discoverability wording;
- delete this workflow from `main` in the same docs commit, so no temporary release machinery remains.

No runtime or package-version change.