### PR TITLE
refactor: standardize plugin build

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/source/**"
+      - "package.json"
       - ".github/workflows/bundle-gate.yml"
   workflow_dispatch:
 
@@ -37,7 +38,7 @@ jobs:
       - run: npm ci
 
       - name: Build a single-file stable plugin from source
-        run: bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool
+        run: npm run build:plugin
 
       - name: Verify generated entry syntax and tests
         run: |

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "check": "node --check src/index.js && node --check scripts/install-node.mjs && node --check scripts/loopd.mjs && node --check scripts/install-test.mjs && node --check scripts/loopd-test.mjs && node --check scripts/smoke-test.mjs && node --check scripts/comprehensive-test.mjs && node --check scripts/host-loop-canary.mjs",
+    "build:plugin": "bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
+    "check": "node --check src/source/v1.js && node --check src/source/legacy-v1.js && node --check src/index.js && node --check scripts/install-node.mjs && node --check scripts/loopd.mjs && node --check scripts/install-test.mjs && node --check scripts/loopd-test.mjs && node --check scripts/smoke-test.mjs && node --check scripts/comprehensive-test.mjs && node --check scripts/host-loop-canary.mjs",
     "test": "node scripts/install-test.mjs && node scripts/loopd-test.mjs && node scripts/smoke-test.mjs && node scripts/comprehensive-test.mjs",
     "canary:host": "node scripts/host-loop-canary.mjs",
     "install:global": "node scripts/install-node.mjs",


### PR DESCRIPTION
Use a single package script for the existing bundle gate and add source syntax checks. Runtime entry stays unchanged.