### PR TITLE
build: rebuild plugin during npm pack

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -37,6 +37,10 @@ jobs:
 
       - run: npm ci
 
+      - name: Verify npm prepack build path
+        if: matrix.os == 'ubuntu-latest'
+        run: npm pack --dry-run
+
       - name: Build a single-file stable plugin from source
         run: npm run build:plugin
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build:plugin": "bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
-    "build:plugin:npm": "npx --yes bun@1.3.14 build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
+    "build:plugin:npm": "npm exec --yes --package=bun@1.3.14 -- bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
     "prepack": "npm run build:plugin:npm && node --check src/index.js",
     "check": "node --check src/source/v1.js && node --check src/source/legacy-v1.js && node --check src/index.js && node --check scripts/install-node.mjs && node --check scripts/loopd.mjs && node --check scripts/install-test.mjs && node --check scripts/loopd-test.mjs && node --check scripts/smoke-test.mjs && node --check scripts/comprehensive-test.mjs && node --check scripts/host-loop-canary.mjs",
     "test": "node scripts/install-test.mjs && node scripts/loopd-test.mjs && node scripts/smoke-test.mjs && node scripts/comprehensive-test.mjs",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build:plugin": "bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
-    "build:plugin:npm": "npm exec --yes --package=bun@1.3.14 -- bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
+    "build:plugin:npm": "npm install --no-save --package-lock=false bun@1.3.14 && bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
     "prepack": "npm run build:plugin:npm && node --check src/index.js",
     "check": "node --check src/source/v1.js && node --check src/source/legacy-v1.js && node --check src/index.js && node --check scripts/install-node.mjs && node --check scripts/loopd.mjs && node --check scripts/install-test.mjs && node --check scripts/loopd-test.mjs && node --check scripts/smoke-test.mjs && node --check scripts/comprehensive-test.mjs && node --check scripts/host-loop-canary.mjs",
     "test": "node scripts/install-test.mjs && node scripts/loopd-test.mjs && node scripts/smoke-test.mjs && node scripts/comprehensive-test.mjs",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   ],
   "scripts": {
     "build:plugin": "bun build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
+    "build:plugin:npm": "npx --yes bun@1.3.14 build src/source/v1.js --outfile=src/index.js --target=bun --format=esm --external=@opencode-ai/plugin/tool",
+    "prepack": "npm run build:plugin:npm && node --check src/index.js",
     "check": "node --check src/source/v1.js && node --check src/source/legacy-v1.js && node --check src/index.js && node --check scripts/install-node.mjs && node --check scripts/loopd.mjs && node --check scripts/install-test.mjs && node --check scripts/loopd-test.mjs && node --check scripts/smoke-test.mjs && node --check scripts/comprehensive-test.mjs && node --check scripts/host-loop-canary.mjs",
     "test": "node scripts/install-test.mjs && node scripts/loopd-test.mjs && node scripts/smoke-test.mjs && node scripts/comprehensive-test.mjs",
     "canary:host": "node scripts/host-loop-canary.mjs",


### PR DESCRIPTION
Add a prepack build from modular source and test that path with npm pack dry-run in the existing bundle gate.