### PR TITLE
Add normalized runtime event contract

### DIFF
--- a/.github/workflows/v2-event-contract.yml
+++ b/.github/workflows/v2-event-contract.yml
@@ -1,0 +1,34 @@
+name: V2 Event Contract
+
+on:
+  pull_request:
+    paths:
+      - "src/source/runtime/events.js"
+      - "scripts/runtime-event-test.mjs"
+      - ".github/workflows/v2-event-contract.yml"
+  push:
+    branches:
+      - main
+      - v2-event-normalizer
+    paths:
+      - "src/source/runtime/events.js"
+      - "scripts/runtime-event-test.mjs"
+      - ".github/workflows/v2-event-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  event-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: node --check src/source/runtime/events.js
+      - run: node --check scripts/runtime-event-test.mjs
+      - run: node scripts/runtime-event-test.mjs

--- a/scripts/runtime-event-test.mjs
+++ b/scripts/runtime-event-test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { normalizeOpenCodeEvent } from "../src/source/runtime/events.js"
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({ type: "session.idle", properties: { sessionID: "ses_idle" } }),
+  { kind: "session", action: "idle", sessionID: "ses_idle", directory: undefined },
+)
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({
+    directory: "/workspace",
+    payload: { type: "session.status", properties: { sessionID: "ses_busy", status: { type: "busy" } } },
+  }),
+  { kind: "session", action: "status", sessionID: "ses_busy", directory: "/workspace", status: "busy" },
+)
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({
+    type: "session.created",
+    properties: { info: { id: "ses_child", directory: "/project", parentID: "ses_parent" } },
+  }),
+  { kind: "session", action: "created", sessionID: "ses_child", directory: "/project", parentID: "ses_parent" },
+)
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({
+    directory: "/workspace",
+    payload: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_done",
+          sessionID: "ses_message",
+          role: "assistant",
+          time: { created: 10, completed: 20 },
+          finish: "stop",
+        },
+      },
+    },
+  }),
+  {
+    kind: "message",
+    action: "updated",
+    sessionID: "ses_message",
+    directory: "/workspace",
+    messageID: "msg_done",
+    role: "assistant",
+    completedAt: 20,
+    finish: "stop",
+  },
+)
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({
+    type: "command.executed",
+    properties: { name: "loop-status", sessionID: "ses_command", arguments: "--json", messageID: "msg_command" },
+  }),
+  {
+    kind: "command",
+    action: "executed",
+    sessionID: "ses_command",
+    directory: undefined,
+    name: "loop-status",
+    arguments: "--json",
+    messageID: "msg_command",
+  },
+)
+
+assert.deepEqual(
+  normalizeOpenCodeEvent({ type: "server.instance.disposed", properties: { directory: "/old" } }),
+  { kind: "server", action: "disposed", directory: "/old" },
+)
+
+assert.equal(normalizeOpenCodeEvent({ type: "session.idle", properties: {} }), undefined)
+assert.equal(normalizeOpenCodeEvent({ payload: { properties: {} } }), undefined)
+assert.equal(normalizeOpenCodeEvent({ type: "file.edited", properties: { file: "x.txt" } }), undefined)
+
+console.log("OpenCode runtime event normalization test passed")

--- a/src/source/runtime/events.js
+++ b/src/source/runtime/events.js
@@ -1,0 +1,109 @@
+function record(value) {
+  return value && typeof value === "object" ? value : undefined
+}
+
+function text(value) {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function envelope(input) {
+  const outer = record(input)
+  if (!outer) return undefined
+  const payload = record(outer.payload)
+  if (payload && text(payload.type)) {
+    return { directory: text(outer.directory), event: payload }
+  }
+  if (!text(outer.type)) return undefined
+  return { directory: undefined, event: outer }
+}
+
+function freezeEvent(value) {
+  return Object.freeze(value)
+}
+
+export function normalizeOpenCodeEvent(input) {
+  const parsed = envelope(input)
+  if (!parsed) return undefined
+
+  const { directory, event } = parsed
+  const properties = record(event.properties) || {}
+
+  if (event.type === "session.status") {
+    const sessionID = text(properties.sessionID)
+    const status = text(record(properties.status)?.type)
+    if (!sessionID || !status) return undefined
+    return freezeEvent({ kind: "session", action: "status", sessionID, directory, status })
+  }
+
+  if (event.type === "session.idle" || event.type === "session.compacted") {
+    const sessionID = text(properties.sessionID)
+    if (!sessionID) return undefined
+    return freezeEvent({
+      kind: "session",
+      action: event.type === "session.idle" ? "idle" : "compacted",
+      sessionID,
+      directory,
+    })
+  }
+
+  if (event.type === "session.created" || event.type === "session.updated" || event.type === "session.deleted") {
+    const info = record(properties.info)
+    const sessionID = text(info?.id)
+    if (!sessionID) return undefined
+    return freezeEvent({
+      kind: "session",
+      action: event.type.slice("session.".length),
+      sessionID,
+      directory: directory || text(info?.directory),
+      parentID: text(info?.parentID),
+    })
+  }
+
+  if (event.type === "session.error") {
+    const sessionID = text(properties.sessionID)
+    if (!sessionID) return undefined
+    return freezeEvent({ kind: "session", action: "error", sessionID, directory })
+  }
+
+  if (event.type === "message.updated") {
+    const info = record(properties.info)
+    const sessionID = text(info?.sessionID)
+    const messageID = text(info?.id)
+    const role = text(info?.role)
+    if (!sessionID || !messageID || !role) return undefined
+    const time = record(info?.time)
+    return freezeEvent({
+      kind: "message",
+      action: "updated",
+      sessionID,
+      directory,
+      messageID,
+      role,
+      completedAt: Number.isFinite(time?.completed) ? time.completed : undefined,
+      finish: text(info?.finish),
+    })
+  }
+
+  if (event.type === "command.executed") {
+    const sessionID = text(properties.sessionID)
+    const name = text(properties.name)
+    if (!sessionID || !name) return undefined
+    return freezeEvent({
+      kind: "command",
+      action: "executed",
+      sessionID,
+      directory,
+      name,
+      arguments: typeof properties.arguments === "string" ? properties.arguments : "",
+      messageID: text(properties.messageID),
+    })
+  }
+
+  if (event.type === "server.instance.disposed") {
+    const disposedDirectory = directory || text(properties.directory)
+    if (!disposedDirectory) return undefined
+    return freezeEvent({ kind: "server", action: "disposed", directory: disposedDirectory })
+  }
+
+  return undefined
+}


### PR DESCRIPTION
Adds a host-neutral event normalizer for current OpenCode session/message/command events, including V2 GlobalEvent wrappers. The stable V1 entry/runtime is untouched. A small read-only workflow verifies the event contract.