### PR TITLE
Add capability-gated OpenCode V2 adapter

### DIFF
--- a/.github/workflows/v2-contract.yml
+++ b/.github/workflows/v2-contract.yml
@@ -1,0 +1,41 @@
+name: V2 Experimental Contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  v2-adapter-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install V2 plugin contract target
+        run: npm install --no-save --package-lock=false @opencode-ai/plugin@1.18.18
+
+      - name: Show V2 plugin package version
+        run: node -p "require('./node_modules/@opencode-ai/plugin/package.json').version"
+
+      - name: Verify V2 adapter contract
+        run: |
+          node --check src/source/opencode2/experimental.js
+          node --check test/v2-adapter.test.mjs
+          node test/v2-adapter.test.mjs
+          node scripts/session-manager-test.mjs

--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,0 +1,82 @@
+import { define } from "@opencode-ai/plugin/v2/promise"
+import { createSessionRuntimeManager } from "../runtime/session-manager.js"
+
+export const V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
+
+export const V2_AUTONOMOUS_REQUIREMENTS = Object.freeze([
+  "sessionGet",
+  "sessionPrompt",
+  "sessionHook",
+  "sessionWait",
+  "eventSubscribe",
+  "toolHook",
+])
+
+export function detectV2Capabilities(ctx) {
+  return Object.freeze({
+    pluginList: typeof ctx?.plugin?.list === "function",
+    commandTransform: typeof ctx?.command?.transform === "function",
+    sessionGet: typeof ctx?.session?.get === "function",
+    sessionPrompt: typeof ctx?.session?.prompt === "function",
+    sessionHook: typeof ctx?.session?.hook === "function",
+    sessionWait: typeof ctx?.session?.wait === "function",
+    sessionInterrupt: typeof ctx?.session?.interrupt === "function",
+    eventSubscribe: typeof ctx?.event?.subscribe === "function",
+    toolHook: typeof ctx?.tool?.hook === "function",
+    toolTransform: typeof ctx?.tool?.transform === "function",
+  })
+}
+
+export function missingLoopV2Capabilities(capabilities) {
+  return V2_AUTONOMOUS_REQUIREMENTS.filter((name) => capabilities?.[name] !== true)
+}
+
+export function inspectLoopV2Readiness(ctx) {
+  const capabilities = detectV2Capabilities(ctx)
+  const missing = missingLoopV2Capabilities(capabilities)
+  return Object.freeze({
+    capabilities,
+    missing: Object.freeze(missing),
+    autonomousReady: missing.length === 0,
+  })
+}
+
+function sessionIDFromObservation(value) {
+  return String(
+    value?.sessionID
+      || value?.session?.id
+      || value?.session?.sessionID
+      || value?.properties?.sessionID
+      || value?.properties?.session?.id
+      || "",
+  ).trim()
+}
+
+export function createV2AdapterRuntime(options = {}) {
+  const manager = options.manager || createSessionRuntimeManager(options.runtime)
+
+  return Object.freeze({
+    observe(value) {
+      const sessionID = sessionIDFromObservation(value)
+      if (!sessionID) return undefined
+      return manager.observeExternal(sessionID)
+    },
+    peek: (sessionID) => manager.peek(sessionID),
+    entries: () => manager.entries(),
+    pruneStale: (at) => manager.pruneStale(at),
+    dispose: (reason) => manager.dispose(reason),
+  })
+}
+
+export const OpenCodeLoopV2Experimental = define({
+  id: V2_PLUGIN_ID,
+  setup: async (ctx) => {
+    // The published V2 Promise package currently exposes the transform/plugin
+    // domains but its typed context has not yet caught up with the documented
+    // session/event/tool runtime surface. Keep activation side-effect free until
+    // all capabilities needed by the autonomous scheduler are present.
+    inspectLoopV2Readiness(ctx)
+  },
+})
+
+export default OpenCodeLoopV2Experimental

--- a/test/v2-adapter.test.mjs
+++ b/test/v2-adapter.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict"
+import plugin, { V2_PLUGIN_ID, inspectLoopV2Readiness } from "../src/source/opencode2/experimental.js"
+
+assert.equal(plugin.id, V2_PLUGIN_ID)
+assert.equal(typeof plugin.setup, "function")
+
+const readiness = inspectLoopV2Readiness({})
+assert.equal(readiness.autonomousReady, false)
+assert.ok(readiness.missing.length > 0)
+
+console.log("V2 adapter contract passed")


### PR DESCRIPTION
Adds an isolated experimental V2 adapter on top of current main. Stable V1 runtime, generated entry, package exports, and V1 test commands are unchanged. The adapter imports the official V2 Promise entrypoint, reports fail-closed readiness until the documented session/event/tool runtime capabilities are actually present, and reuses the new session runtime manager. A separate V2 contract workflow tests against @opencode-ai/plugin@1.18.18 without changing the V1 compatibility matrix.