### PR TITLE
Add V2 lifecycle contract

### DIFF
--- a/.github/workflows/v2-lifecycle-contract.yml
+++ b/.github/workflows/v2-lifecycle-contract.yml
@@ -1,0 +1,44 @@
+name: V2 Lifecycle Contract
+
+on:
+  pull_request:
+    paths:
+      - "src/source/opencode2/**"
+      - "src/source/runtime/**"
+      - "scripts/v2-event-bridge-test.mjs"
+      - "scripts/v2-plugin-sentinel-test.mjs"
+      - ".github/workflows/v2-lifecycle-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/source/opencode2/**"
+      - "src/source/runtime/**"
+      - "scripts/v2-event-bridge-test.mjs"
+      - "scripts/v2-plugin-sentinel-test.mjs"
+      - ".github/workflows/v2-lifecycle-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lifecycle-contract:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci
+      - run: node --check src/source/opencode2/event-bridge.js
+      - run: node --check src/source/opencode2/experimental.js
+      - run: node --check scripts/v2-event-bridge-test.mjs
+      - run: node scripts/v2-event-bridge-test.mjs
+      - run: node scripts/v2-plugin-sentinel-test.mjs

--- a/scripts/v2-event-bridge-test.mjs
+++ b/scripts/v2-event-bridge-test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+import { createOpenCode2EventBridge } from "../src/source/opencode2/event-bridge.js"
+
+const seen = []
+let listener
+let unsubscribeCalls = 0
+
+const bridge = createOpenCode2EventBridge({
+  directory: "/project",
+  onEvent: async (event, runtime) => seen.push({ event, runtime }),
+})
+
+await bridge.attach(async (callback) => {
+  listener = callback
+  return { unsubscribe: async () => { unsubscribeCalls += 1 } }
+})
+
+await listener({
+  directory: "/project",
+  payload: { type: "session.created", properties: { info: { id: "ses_a", directory: "/project" } } },
+})
+const first = bridge.runtimeManager.peek("ses_a")
+assert.ok(first)
+assert.equal(first.scope.isActive(), true)
+
+await listener({
+  directory: "/project",
+  payload: { type: "session.status", properties: { sessionID: "ses_a", status: { type: "busy" } } },
+})
+assert.equal(bridge.runtimeManager.peek("ses_a"), first)
+
+await listener({
+  directory: "/project",
+  payload: { type: "session.created", properties: { info: { id: "ses_b", directory: "/project" } } },
+})
+const second = bridge.runtimeManager.peek("ses_b")
+assert.ok(second)
+assert.notEqual(second, first)
+
+await listener({
+  directory: "/other-project",
+  payload: { type: "session.status", properties: { sessionID: "ses_other", status: { type: "busy" } } },
+})
+assert.equal(bridge.runtimeManager.peek("ses_other"), undefined)
+
+await listener({
+  directory: "/project",
+  payload: { type: "session.deleted", properties: { info: { id: "ses_a", directory: "/project" } } },
+})
+assert.equal(bridge.runtimeManager.peek("ses_a"), undefined)
+assert.equal(first.scope.isActive(), false)
+assert.equal(second.scope.isActive(), true)
+
+await listener({
+  directory: "/project",
+  payload: { type: "server.instance.disposed", properties: { directory: "/project" } },
+})
+assert.equal(second.scope.isActive(), false)
+assert.deepEqual(bridge.runtimeManager.entries(), [])
+
+const seenCount = seen.length
+await listener({
+  directory: "/project",
+  payload: { type: "session.status", properties: { sessionID: "ses_late", status: { type: "busy" } } },
+})
+assert.equal(seen.length, seenCount)
+
+assert.equal(await bridge.dispose(), true)
+assert.equal(await bridge.dispose(), false)
+assert.equal(unsubscribeCalls, 1)
+
+console.log("OpenCode 2 event bridge lifecycle passed")

--- a/src/source/opencode2/event-bridge.js
+++ b/src/source/opencode2/event-bridge.js
@@ -1,0 +1,103 @@
+import { normalizeOpenCodeEvent } from "../runtime/events.js"
+import { createSessionRuntimeManager } from "../runtime/session-manager.js"
+
+function cleanupRegistration(registration) {
+  if (typeof registration === "function") return registration
+  if (!registration || typeof registration !== "object") return undefined
+  for (const key of ["dispose", "unsubscribe", "close"]) {
+    if (typeof registration[key] === "function") return registration[key].bind(registration)
+  }
+  return undefined
+}
+
+function sameDirectory(expected, actual) {
+  if (!expected || !actual) return true
+  return String(expected) === String(actual)
+}
+
+export function createOpenCode2EventBridge({
+  directory,
+  onEvent = async () => {},
+  onError = () => {},
+  runtimeManager = createSessionRuntimeManager(),
+} = {}) {
+  if (typeof onEvent !== "function") throw new TypeError("OpenCode 2 event bridge requires onEvent to be a function")
+  if (typeof onError !== "function") throw new TypeError("OpenCode 2 event bridge requires onError to be a function")
+
+  let registration
+  let attached = false
+  let stopped = false
+  let disposed = false
+  let managerDisposed = false
+  let queue = Promise.resolve()
+
+  function disposeManager(reason) {
+    if (managerDisposed) return false
+    managerDisposed = true
+    return runtimeManager.dispose(reason)
+  }
+
+  async function process(raw) {
+    if (stopped) return undefined
+    const event = normalizeOpenCodeEvent(raw)
+    if (!event || !sameDirectory(directory, event.directory)) return undefined
+
+    const runtime = event.sessionID ? runtimeManager.observeExternal(event.sessionID) : undefined
+    await onEvent(event, runtime)
+
+    if (event.kind === "session" && event.action === "deleted") {
+      runtimeManager.remove(event.sessionID, { expectedRuntime: runtime, reason: "session-deleted" })
+    }
+
+    if (event.kind === "server" && event.action === "disposed") {
+      stopped = true
+      disposeManager("server-disposed")
+    }
+
+    return event
+  }
+
+  function dispatch(raw) {
+    if (stopped) return Promise.resolve(undefined)
+    const result = queue.then(() => process(raw))
+    queue = result.catch(() => undefined)
+    return result
+  }
+
+  async function attach(subscribe) {
+    if (disposed) throw new Error("OpenCode 2 event bridge is disposed")
+    if (attached) throw new Error("OpenCode 2 event bridge is already attached")
+    if (typeof subscribe !== "function") throw new TypeError("OpenCode 2 event bridge requires an event subscribe function")
+    attached = true
+    registration = await subscribe((raw) => {
+      const pending = dispatch(raw)
+      pending.catch((error) => {
+        try { onError(error) } catch {}
+      })
+      return pending.catch(() => undefined)
+    })
+    return registration
+  }
+
+  async function dispose(reason = "bridge-disposed") {
+    if (disposed) return false
+    disposed = true
+    stopped = true
+    await queue.catch(() => undefined)
+
+    const cleanup = cleanupRegistration(registration)
+    registration = undefined
+    if (cleanup) await cleanup()
+    disposeManager(reason)
+    return true
+  }
+
+  return Object.freeze({
+    attach,
+    dispatch,
+    dispose,
+    runtimeManager,
+    isAttached: () => attached,
+    isDisposed: () => disposed,
+  })
+}

--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,5 +1,6 @@
 import { define } from "@opencode-ai/plugin/v2/promise"
 import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2EventBridge } from "./event-bridge.js"
 
 export const OPENCODE_LOOP_V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
 
@@ -12,6 +13,15 @@ export const OpenCodeLoopV2ExperimentalPlugin = define({
     }
 
     await ctx.command.transform(() => {})
+
+    const bridge = createOpenCode2EventBridge()
+    if (typeof ctx?.event?.subscribe === "function") {
+      await bridge.attach(ctx.event.subscribe.bind(ctx.event))
+    }
+
+    return async () => {
+      await bridge.dispose("plugin-cleanup")
+    }
   },
 })
 


### PR DESCRIPTION
Adds isolated V2 lifecycle modules and tests. Existing V1 runtime and package export remain unchanged.