### PR TITLE
Observe stable V1 events through shared runtime

### DIFF
--- a/src/source/runtime/events.js
+++ b/src/source/runtime/events.js
@@ -13,6 +13,10 @@ function envelope(input) {
   if (payload && text(payload.type)) {
     return { directory: text(outer.directory), event: payload }
   }
+  const wrappedEvent = record(outer.event)
+  if (wrappedEvent && text(wrappedEvent.type)) {
+    return { directory: text(outer.directory), event: wrappedEvent }
+  }
   if (!text(outer.type)) return undefined
   return { directory: undefined, event: outer }
 }

--- a/src/source/runtime/observer.js
+++ b/src/source/runtime/observer.js
@@ -1,0 +1,23 @@
+import { normalizeOpenCodeEvent } from "./events.js"
+
+export function observeRuntimeEvent(manager, input) {
+  const event = normalizeOpenCodeEvent(input)
+  if (!event || !manager) return event
+
+  try {
+    if (event.kind === "server" && event.action === "disposed") {
+      manager.dispose?.("server-disposed")
+      return event
+    }
+
+    if (!event.sessionID) return event
+    if (event.kind === "session" && event.action === "deleted") {
+      manager.remove?.(event.sessionID, { reason: "session-deleted" })
+      return event
+    }
+
+    manager.observeExternal?.(event.sessionID)
+  } catch {}
+
+  return event
+}

--- a/src/source/v1.js
+++ b/src/source/v1.js
@@ -1,4 +1,6 @@
 import LegacyOpenCodeLoopPlugin from "./legacy-v1.js"
+import { createSessionRuntimeManager } from "./runtime/session-manager.js"
+import { observeRuntimeEvent } from "./runtime/observer.js"
 
 const clientGenerations = new WeakMap()
 
@@ -43,12 +45,21 @@ export const OpenCodeLoopPlugin = async (input = {}) => {
   const legacyDispose = typeof hooks?.dispose === "function" ? hooks.dispose.bind(hooks) : undefined
   if (!legacyDispose) return hooks
 
+  const runtimeManager = createSessionRuntimeManager()
+  const legacyEvent = typeof hooks?.event === "function" ? hooks.event.bind(hooks) : undefined
   let disposed = false
   return {
     ...hooks,
+    ...(legacyEvent ? {
+      event: async (payload) => {
+        observeRuntimeEvent(runtimeManager, payload)
+        return await legacyEvent(payload)
+      },
+    } : {}),
     dispose: async () => {
       if (disposed) return
       disposed = true
+      try { runtimeManager.dispose("plugin-disposed") } catch {}
       await legacyDispose()
       scheduleLegacyCleanup(legacyDispose, isCurrentGeneration)
     },


### PR DESCRIPTION
Adds a fail-open runtime observer beside the existing legacy V1 scheduler. Stable V1 behavior still delegates to legacy hooks; the shared runtime manager only observes normalized lifecycle events. Also teaches the event normalizer the V1 `{ event }` envelope. No OpenCode 2 capability or adapter files are changed.