### PR TITLE
Prepare 0.5.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bybrawe/opencode-loop",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "Claude Code/Codex style /loop and experimental goal mode for OpenCode: heartbeat scheduler, idle-safe loops, scheduled commands, compact scheduling, verification, checkpoints, and persistent coding goals.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Version-only release prep on top of the fully green modularization/V2-contract head. No runtime source changes in this PR.