### PR TITLE
Connect the experimental V2 context lifecycle

### DIFF
--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,4 +1,5 @@
 import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2HostContract } from "./host-contract.js"
 
 export const OPENCODE_LOOP_V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
 
@@ -9,7 +10,20 @@ export const OpenCodeLoopV2ExperimentalPlugin = {
     if (!capabilities.commandTransform) {
       throw new Error("OpenCode 2 command.transform capability is unavailable")
     }
+
     await ctx.command.transform(() => {})
+    if (!capabilities.eventSubscribe || !capabilities.sessionPrompt) return undefined
+
+    const subscribe = () => ctx.event.subscribe()
+    const sendPrompt = (request) => ctx.session.prompt(request)
+    const options = {}
+    options.subscribe = subscribe
+    options.sendPrompt = sendPrompt
+    const host = createOpenCode2HostContract(options)
+    const startHost = host.start.bind(host)
+    const disposeHost = host.dispose.bind(host)
+    await startHost()
+    return disposeHost
   },
 }
 


### PR DESCRIPTION
Single-file V2-only change based on the current main. Stable V1 source and generated entry are unchanged.