### PR TITLE
Add first functional OpenCode 2 loop command

### DIFF
--- a/.github/workflows/v2-lifecycle-contract.yml
+++ b/.github/workflows/v2-lifecycle-contract.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/v2-event-stream-contract-test.mjs"
       - "scripts/v2-host-contract-test.mjs"
       - "scripts/v2-plugin-sentinel-test.mjs"
+      - "scripts/v2-loop-status-test.mjs"
       - ".github/workflows/v2-lifecycle-contract.yml"
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - "scripts/v2-event-stream-contract-test.mjs"
       - "scripts/v2-host-contract-test.mjs"
       - "scripts/v2-plugin-sentinel-test.mjs"
+      - "scripts/v2-loop-status-test.mjs"
       - ".github/workflows/v2-lifecycle-contract.yml"
 
 permissions:
@@ -43,11 +45,14 @@ jobs:
       - run: npm ci
       - run: node --check src/source/opencode2/event-bridge.js
       - run: node --check src/source/opencode2/host-contract.js
+      - run: node --check src/source/opencode2/status.js
       - run: node --check src/source/opencode2/experimental.js
       - run: node --check scripts/v2-event-bridge-test.mjs
       - run: node --check scripts/v2-event-stream-contract-test.mjs
       - run: node --check scripts/v2-host-contract-test.mjs
+      - run: node --check scripts/v2-loop-status-test.mjs
       - run: node scripts/v2-event-bridge-test.mjs
       - run: node scripts/v2-event-stream-contract-test.mjs
       - run: node scripts/v2-host-contract-test.mjs
       - run: node scripts/v2-plugin-sentinel-test.mjs
+      - run: node scripts/v2-loop-status-test.mjs

--- a/scripts/v2-loop-status-test.mjs
+++ b/scripts/v2-loop-status-test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import plugin from "../src/source/opencode2/experimental.js"
+import { writeState } from "../src/source/core/state.js"
+
+const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-loop-v2-status-"))
+const sessionID = "ses_v2_status"
+let listener
+let transforms = 0
+const prompts = []
+
+const ctx = {
+  command: {
+    transform: async () => {
+      transforms += 1
+      return { dispose: async () => {} }
+    },
+  },
+  event: {
+    subscribe: async (callback) => {
+      listener = callback
+      return { dispose: async () => {} }
+    },
+  },
+  session: {
+    prompt: async (request) => {
+      prompts.push(structuredClone(request))
+      return { accepted: true }
+    },
+  },
+}
+
+try {
+  await plugin.setup(ctx)
+  assert.equal(transforms, 1)
+  assert.equal(typeof listener, "function")
+
+  await listener({
+    directory,
+    payload: {
+      type: "command.executed",
+      properties: { name: "loop-status", sessionID, arguments: "", messageID: "msg_status_empty" },
+    },
+  })
+
+  assert.equal(prompts.length, 1)
+  assert.equal(prompts[0].sessionID, sessionID)
+  assert.equal(prompts[0].noReply, true)
+  assert.deepEqual(prompts[0].parts, [{ type: "text", text: "OpenCode loop status:\nNo active loop jobs." }])
+
+  await writeState(directory, sessionID, {
+    version: 4,
+    jobs: [{
+      id: "job_status",
+      name: "status-test",
+      action: "continue safely",
+      kind: "prompt",
+      intervalMs: 60_000,
+      lastRunAt: Date.now(),
+      runCount: 2,
+      failureCount: 1,
+      noOverlap: true,
+    }],
+  })
+
+  await listener({
+    directory,
+    payload: {
+      type: "command.executed",
+      properties: { name: "loop-status", sessionID, arguments: "", messageID: "msg_status_job" },
+    },
+  })
+
+  assert.equal(prompts.length, 2)
+  const statusText = prompts[1].parts[0].text
+  assert.match(statusText, /^OpenCode loop status:/)
+  assert.match(statusText, /job_status \(status-test\)/)
+  assert.match(statusText, /continue safely/)
+  assert.match(statusText, /runs=2/)
+  assert.match(statusText, /failures=1/)
+  assert.match(statusText, /active,no-overlap/)
+
+  await listener({
+    directory,
+    payload: {
+      type: "command.executed",
+      properties: { name: "loop-help", sessionID, arguments: "", messageID: "msg_help" },
+    },
+  })
+  assert.equal(prompts.length, 2, "the V2 status slice must ignore commands it does not own yet")
+
+  console.log("OpenCode 2 loop status contract passed")
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}

--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,4 +1,6 @@
 import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2HostContract } from "./host-contract.js"
+import { handleOpenCode2LoopStatus } from "./status.js"
 
 export const OPENCODE_LOOP_V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
 
@@ -6,10 +8,30 @@ export const OpenCodeLoopV2ExperimentalPlugin = {
   id: OPENCODE_LOOP_V2_PLUGIN_ID,
   async setup(ctx) {
     const capabilities = inspectOpenCode2Context(ctx)
-    if (!capabilities.commandTransform) {
-      throw new Error("OpenCode 2 command.transform capability is unavailable")
-    }
+    if (!capabilities.commandTransform) throw new Error("OpenCode 2 command.transform capability is unavailable")
+    if (!capabilities.eventSubscribe) throw new Error("OpenCode 2 event.subscribe capability is unavailable")
+    if (!capabilities.sessionPrompt) throw new Error("OpenCode 2 session.prompt capability is unavailable")
+
     await ctx.command.transform(() => {})
+
+    let host
+    host = createOpenCode2HostContract({
+      subscribe: ctx.event.subscribe.bind(ctx.event),
+      sendPrompt: async (request) => await ctx.session.prompt({
+        sessionID: request.sessionID,
+        noReply: request.noReply,
+        parts: [{ type: "text", text: request.text }],
+      }),
+      onEvent: async (event) => {
+        if (event.kind !== "command" || event.action !== "executed" || event.name !== "loop-status") return
+        await handleOpenCode2LoopStatus({
+          directory: event.directory,
+          sessionID: event.sessionID,
+          prompt: host.prompt,
+        })
+      },
+    })
+    await host.start()
   },
 }
 

--- a/src/source/opencode2/status.js
+++ b/src/source/opencode2/status.js
@@ -1,0 +1,41 @@
+import { durationToText, now } from "../core/args.js"
+import { goalStatusText, isGoalJob, jobLabel } from "../core/jobs.js"
+import { readState } from "../core/state.js"
+
+export function formatOpenCode2LoopStatus(state) {
+  const jobs = Array.isArray(state?.jobs) ? state.jobs : []
+  const lines = jobs.length
+    ? jobs.map((job, index) => {
+        const dueIn = Math.max(0, Number(job.intervalMs || 0) - (now() - Number(job.lastRunAt || 0)))
+        const flags = [
+          isGoalJob(job) ? `goal:${goalStatusText(job)}` : undefined,
+          job.paused ? "paused" : "active",
+          job.safe ? "safe" : undefined,
+          job.askNever ? "ask-never" : undefined,
+          job.noOverlap ? "no-overlap" : undefined,
+          job.checkpointOnly ? "checkpoint-only" : undefined,
+          job.gitCheckpoint ? "git-checkpoint" : undefined,
+        ].filter(Boolean).join(",")
+        return `${index + 1}. ${job.id}${job.name ? ` (${job.name})` : ""}: ${jobLabel(job)} | runs=${job.runCount || 0} | failures=${job.failureCount || 0} | due in ${durationToText(dueIn)} | ${flags}`
+      })
+    : ["No active loop jobs."]
+
+  return Object.freeze({
+    jobs,
+    text: `OpenCode loop status:\n${lines.join("\n")}`,
+  })
+}
+
+export async function handleOpenCode2LoopStatus({ directory, sessionID, prompt }) {
+  if (!directory) throw new TypeError("V2 loop status requires a project directory")
+  if (!sessionID) throw new TypeError("V2 loop status requires a session ID")
+  if (typeof prompt !== "function") throw new TypeError("V2 loop status requires a prompt function")
+
+  const status = formatOpenCode2LoopStatus(await readState(directory, sessionID))
+  await prompt({
+    sessionID,
+    text: status.text,
+    noReply: true,
+  })
+  return status
+}


### PR DESCRIPTION
Superseded by a clean branch based on the newer V2 host lifecycle commit. The old branch conflicted with main's concurrent `experimental.js` lifecycle work and will not be merged.