### PR TITLE
Wire experimental OpenCode 2 runtime host bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,18 @@ jobs:
           node --check src/source/runtime/timers.js
           node --check src/source/runtime/session-manager.js
           node --check src/source/opencode2/capabilities.js
+          node --check src/source/opencode2/runtime-adapter.js
           node --check src/source/opencode2/experimental.js
           node --check scripts/runtime-contract-test.mjs
           node --check scripts/runtime-scope-test.mjs
           node --check scripts/session-manager-test.mjs
           node --check scripts/v2-plugin-sentinel-test.mjs
+          node --check scripts/v2-runtime-adapter-test.mjs
           node scripts/runtime-contract-test.mjs
           node scripts/runtime-scope-test.mjs
           node scripts/session-manager-test.mjs
           node scripts/v2-plugin-sentinel-test.mjs
+          node scripts/v2-runtime-adapter-test.mjs
 
       - run: npm test
 

--- a/scripts/fixtures/opencode2-real-adapter-probe.js
+++ b/scripts/fixtures/opencode2-real-adapter-probe.js
@@ -11,7 +11,7 @@ export default {
     const module = await import(pluginURL)
     const plugin = module.default
     if (!plugin || typeof plugin.setup !== "function") throw new Error("experimental V2 plugin has no setup function")
-    await plugin.setup(ctx)
+    const cleanup = await plugin.setup(ctx)
 
     await writeFile(marker, JSON.stringify({
       id: plugin.id,
@@ -21,5 +21,9 @@ export default {
       sessionPrompt: typeof ctx?.session?.prompt === "function",
       toolTransform: typeof ctx?.tool?.transform === "function",
     }, null, 2), "utf8")
+
+    return async () => {
+      if (typeof cleanup === "function") await cleanup()
+    }
   },
 }

--- a/scripts/v2-runtime-adapter-test.mjs
+++ b/scripts/v2-runtime-adapter-test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict"
+
+import OpenCodeLoopV2ExperimentalPlugin from "../src/source/opencode2/experimental.js"
+import { createOpenCode2RuntimeAdapter } from "../src/source/opencode2/runtime-adapter.js"
+
+function controllableStream() {
+  const queued = []
+  const waiting = []
+  let closed = false
+  let returns = 0
+
+  const iterator = {
+    next() {
+      if (queued.length) return Promise.resolve({ done: false, value: queued.shift() })
+      if (closed) return Promise.resolve({ done: true, value: undefined })
+      return new Promise((resolve) => waiting.push(resolve))
+    },
+    async return() {
+      returns += 1
+      closed = true
+      while (waiting.length) waiting.shift()({ done: true, value: undefined })
+      return { done: true, value: undefined }
+    },
+  }
+
+  return {
+    stream: { [Symbol.asyncIterator]: () => iterator },
+    push(value) {
+      if (closed) throw new Error("stream is closed")
+      if (waiting.length) waiting.shift()({ done: false, value })
+      else queued.push(value)
+    },
+    returns: () => returns,
+  }
+}
+
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+{
+  const events = controllableStream()
+  const prompts = []
+  let subscriptions = 0
+  const ctx = {
+    event: {
+      subscribe() {
+        subscriptions += 1
+        return events.stream
+      },
+    },
+    session: {
+      prompt: async (input) => {
+        prompts.push(input)
+        return { accepted: true }
+      },
+    },
+  }
+
+  const adapter = createOpenCode2RuntimeAdapter(ctx)
+  assert.equal(await adapter.start(), true)
+  assert.equal(await adapter.start(), false)
+  assert.equal(subscriptions, 1)
+
+  events.push({
+    directory: "/project",
+    payload: { type: "session.created", properties: { info: { id: "ses_v2", directory: "/project" } } },
+  })
+  await settle()
+  assert.ok(adapter.runtimeManager.peek("ses_v2"), "V2 event stream must create a session runtime")
+
+  const result = await adapter.prompt({ sessionID: "ses_v2", text: "continue" })
+  assert.deepEqual(result, { accepted: true })
+  assert.deepEqual(prompts, [{ sessionID: "ses_v2", text: "continue" }])
+
+  assert.equal(await adapter.dispose("test-complete"), true)
+  assert.equal(await adapter.dispose("test-complete"), false)
+  assert.equal(events.returns(), 1, "disposing the V2 adapter must close the event iterator")
+}
+
+{
+  const events = controllableStream()
+  let commandTransforms = 0
+  let commandDisposals = 0
+  let eventSubscriptions = 0
+  const ctx = {
+    command: {
+      transform: async () => {
+        commandTransforms += 1
+        return { dispose: async () => { commandDisposals += 1 } }
+      },
+    },
+    event: {
+      subscribe() {
+        eventSubscriptions += 1
+        return events.stream
+      },
+    },
+    session: { prompt: async () => ({ accepted: true }) },
+  }
+
+  const cleanup = await OpenCodeLoopV2ExperimentalPlugin.setup(ctx)
+  assert.equal(typeof cleanup, "function")
+  assert.equal(commandTransforms, 1)
+  assert.equal(eventSubscriptions, 1)
+  await cleanup()
+  assert.equal(commandDisposals, 1, "plugin cleanup must dispose command.transform registration")
+  assert.equal(events.returns(), 1, "plugin cleanup must dispose the V2 event subscription")
+}
+
+assert.throws(
+  () => createOpenCode2RuntimeAdapter({ event: {}, session: { prompt: async () => {} } }),
+  /event\.subscribe capability is unavailable/,
+)
+assert.throws(
+  () => createOpenCode2RuntimeAdapter({ event: { subscribe() {} }, session: {} }),
+  /session\.prompt capability is unavailable/,
+)
+
+console.log("OpenCode 2 runtime adapter contract passed")

--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,4 +1,5 @@
 import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2RuntimeAdapter } from "./runtime-adapter.js"
 
 export const OPENCODE_LOOP_V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
 
@@ -9,7 +10,20 @@ export const OpenCodeLoopV2ExperimentalPlugin = {
     if (!capabilities.commandTransform) {
       throw new Error("OpenCode 2 command.transform capability is unavailable")
     }
-    await ctx.command.transform(() => {})
+
+    const commandRegistration = await ctx.command.transform(() => {})
+    const runtime = createOpenCode2RuntimeAdapter(ctx)
+    try {
+      await runtime.start()
+    } catch (error) {
+      await commandRegistration?.dispose?.().catch(() => undefined)
+      throw error
+    }
+
+    return async () => {
+      await runtime.dispose("plugin-cleanup")
+      await commandRegistration?.dispose?.()
+    }
   },
 }
 

--- a/src/source/opencode2/runtime-adapter.js
+++ b/src/source/opencode2/runtime-adapter.js
@@ -1,0 +1,33 @@
+import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2HostContract } from "./host-contract.js"
+
+function promptRequest(request) {
+  return {
+    sessionID: request.sessionID,
+    text: request.text,
+  }
+}
+
+export function createOpenCode2RuntimeAdapter(ctx, options = {}) {
+  const capabilities = inspectOpenCode2Context(ctx)
+  if (!capabilities.eventSubscribe) throw new Error("OpenCode 2 event.subscribe capability is unavailable")
+  if (!capabilities.sessionPrompt) throw new Error("OpenCode 2 session.prompt capability is unavailable")
+
+  const host = createOpenCode2HostContract({
+    directory: options.directory,
+    subscribe: () => ctx.event.subscribe(),
+    sendPrompt: (request) => ctx.session.prompt(promptRequest(request)),
+    onEvent: options.onEvent,
+    onError: options.onError,
+  })
+
+  return Object.freeze({
+    start: () => host.start(),
+    prompt: (request) => host.prompt(request),
+    dispose: (reason = "runtime-adapter-disposed") => host.dispose(reason),
+    runtimeManager: host.runtimeManager,
+    isStarted: host.isStarted,
+    isDisposed: host.isDisposed,
+    isHostDisposed: host.isHostDisposed,
+  })
+}


### PR DESCRIPTION
Experimental OpenCode 2 only. Starts the existing V2 host contract from plugin setup, consumes the Promise API event SSE explicitly, forwards minimal session prompts, and disposes command/event registrations on cleanup. Stable V1 runtime and generated src/index.js are unchanged.