### PR TITLE
Harden experimental OpenCode 2 runtime lifecycle cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,18 @@ jobs:
           node --check src/source/runtime/timers.js
           node --check src/source/runtime/session-manager.js
           node --check src/source/opencode2/capabilities.js
+          node --check src/source/opencode2/runtime-adapter.js
           node --check src/source/opencode2/experimental.js
           node --check scripts/runtime-contract-test.mjs
           node --check scripts/runtime-scope-test.mjs
           node --check scripts/session-manager-test.mjs
           node --check scripts/v2-plugin-sentinel-test.mjs
+          node --check scripts/v2-runtime-adapter-test.mjs
           node scripts/runtime-contract-test.mjs
           node scripts/runtime-scope-test.mjs
           node scripts/session-manager-test.mjs
           node scripts/v2-plugin-sentinel-test.mjs
+          node scripts/v2-runtime-adapter-test.mjs
 
       - run: npm test
 

--- a/scripts/fixtures/opencode2-real-adapter-probe.js
+++ b/scripts/fixtures/opencode2-real-adapter-probe.js
@@ -11,7 +11,7 @@ export default {
     const module = await import(pluginURL)
     const plugin = module.default
     if (!plugin || typeof plugin.setup !== "function") throw new Error("experimental V2 plugin has no setup function")
-    await plugin.setup(ctx)
+    const cleanup = await plugin.setup(ctx)
 
     await writeFile(marker, JSON.stringify({
       id: plugin.id,
@@ -21,5 +21,9 @@ export default {
       sessionPrompt: typeof ctx?.session?.prompt === "function",
       toolTransform: typeof ctx?.tool?.transform === "function",
     }, null, 2), "utf8")
+
+    return async () => {
+      if (typeof cleanup === "function") await cleanup()
+    }
   },
 }

--- a/scripts/v2-runtime-adapter-test.mjs
+++ b/scripts/v2-runtime-adapter-test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict"
+
+import OpenCodeLoopV2ExperimentalPlugin from "../src/source/opencode2/experimental.js"
+import { createOpenCode2RuntimeAdapter } from "../src/source/opencode2/runtime-adapter.js"
+
+function controllableStream() {
+  const queued = []
+  const waiting = []
+  let closed = false
+  let returns = 0
+
+  const iterator = {
+    next() {
+      if (queued.length) return Promise.resolve({ done: false, value: queued.shift() })
+      if (closed) return Promise.resolve({ done: true, value: undefined })
+      return new Promise((resolve) => waiting.push(resolve))
+    },
+    async return() {
+      returns += 1
+      closed = true
+      while (waiting.length) waiting.shift()({ done: true, value: undefined })
+      return { done: true, value: undefined }
+    },
+  }
+
+  return {
+    stream: { [Symbol.asyncIterator]: () => iterator },
+    push(value) {
+      if (closed) throw new Error("stream is closed")
+      if (waiting.length) waiting.shift()({ done: false, value })
+      else queued.push(value)
+    },
+    returns: () => returns,
+  }
+}
+
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+{
+  const events = controllableStream()
+  const prompts = []
+  let subscriptions = 0
+  const ctx = {
+    event: {
+      subscribe() {
+        subscriptions += 1
+        return events.stream
+      },
+    },
+    session: {
+      prompt: async (input) => {
+        prompts.push(input)
+        return { accepted: true }
+      },
+    },
+  }
+
+  const adapter = createOpenCode2RuntimeAdapter(ctx)
+  assert.equal(await adapter.start(), true)
+  assert.equal(await adapter.start(), false)
+  assert.equal(subscriptions, 1)
+
+  events.push({
+    directory: "/project",
+    payload: { type: "session.created", properties: { info: { id: "ses_v2", directory: "/project" } } },
+  })
+  await settle()
+  assert.ok(adapter.runtimeManager.peek("ses_v2"), "V2 event stream must create a session runtime")
+
+  const result = await adapter.prompt({ sessionID: "ses_v2", text: "continue" })
+  assert.deepEqual(result, { accepted: true })
+  assert.deepEqual(prompts, [{ sessionID: "ses_v2", text: "continue" }])
+
+  assert.equal(await adapter.dispose("test-complete"), true)
+  assert.equal(await adapter.dispose("test-complete"), false)
+  assert.equal(events.returns(), 1, "disposing the V2 adapter must close the event iterator")
+}
+
+{
+  const events = controllableStream()
+  let commandTransforms = 0
+  let commandDisposals = 0
+  let eventSubscriptions = 0
+  const ctx = {
+    command: {
+      transform: async () => {
+        commandTransforms += 1
+        return { dispose: async () => { commandDisposals += 1 } }
+      },
+    },
+    event: {
+      subscribe() {
+        eventSubscriptions += 1
+        return events.stream
+      },
+    },
+    session: { prompt: async () => ({ accepted: true }) },
+  }
+
+  const cleanup = await OpenCodeLoopV2ExperimentalPlugin.setup(ctx)
+  assert.equal(typeof cleanup, "function")
+  assert.equal(commandTransforms, 1)
+  assert.equal(eventSubscriptions, 1)
+  await cleanup()
+  assert.equal(commandDisposals, 1, "plugin cleanup must dispose command.transform registration")
+  assert.equal(events.returns(), 1, "plugin cleanup must dispose the V2 event subscription")
+}
+
+{
+  let commandDisposals = 0
+  const result = await OpenCodeLoopV2ExperimentalPlugin.setup({
+    command: {
+      transform: async () => ({ dispose: async () => { commandDisposals += 1 } }),
+    },
+    event: {},
+    session: {},
+  })
+  assert.equal(result, undefined)
+  assert.equal(commandDisposals, 1, "partial V2 hosts must not leak command registrations")
+}
+
+assert.throws(
+  () => createOpenCode2RuntimeAdapter({ event: {}, session: { prompt: async () => {} } }),
+  /event\.subscribe capability is unavailable/,
+)
+assert.throws(
+  () => createOpenCode2RuntimeAdapter({ event: { subscribe() {} }, session: {} }),
+  /session\.prompt capability is unavailable/,
+)
+
+console.log("OpenCode 2 runtime adapter contract passed")

--- a/src/source/opencode2/experimental.js
+++ b/src/source/opencode2/experimental.js
@@ -1,5 +1,5 @@
 import { inspectOpenCode2Context } from "./capabilities.js"
-import { createOpenCode2HostContract } from "./host-contract.js"
+import { createOpenCode2RuntimeAdapter } from "./runtime-adapter.js"
 
 export const OPENCODE_LOOP_V2_PLUGIN_ID = "bybrawe.opencode-loop.v2.experimental"
 
@@ -11,19 +11,24 @@ export const OpenCodeLoopV2ExperimentalPlugin = {
       throw new Error("OpenCode 2 command.transform capability is unavailable")
     }
 
-    await ctx.command.transform(() => {})
-    if (!capabilities.eventSubscribe || !capabilities.sessionPrompt) return undefined
+    const commandRegistration = await ctx.command.transform(() => {})
+    if (!capabilities.eventSubscribe || !capabilities.sessionPrompt) {
+      await commandRegistration?.dispose?.()
+      return undefined
+    }
 
-    const subscribe = () => ctx.event.subscribe()
-    const sendPrompt = (request) => ctx.session.prompt(request)
-    const options = {}
-    options.subscribe = subscribe
-    options.sendPrompt = sendPrompt
-    const host = createOpenCode2HostContract(options)
-    const startHost = host.start.bind(host)
-    const disposeHost = host.dispose.bind(host)
-    await startHost()
-    return disposeHost
+    const runtime = createOpenCode2RuntimeAdapter(ctx)
+    try {
+      await runtime.start()
+    } catch (error) {
+      await commandRegistration?.dispose?.().catch(() => undefined)
+      throw error
+    }
+
+    return async () => {
+      await runtime.dispose("plugin-cleanup")
+      await commandRegistration?.dispose?.()
+    }
   },
 }
 

--- a/src/source/opencode2/runtime-adapter.js
+++ b/src/source/opencode2/runtime-adapter.js
@@ -1,0 +1,33 @@
+import { inspectOpenCode2Context } from "./capabilities.js"
+import { createOpenCode2HostContract } from "./host-contract.js"
+
+function promptRequest(request) {
+  return {
+    sessionID: request.sessionID,
+    text: request.text,
+  }
+}
+
+export function createOpenCode2RuntimeAdapter(ctx, options = {}) {
+  const capabilities = inspectOpenCode2Context(ctx)
+  if (!capabilities.eventSubscribe) throw new Error("OpenCode 2 event.subscribe capability is unavailable")
+  if (!capabilities.sessionPrompt) throw new Error("OpenCode 2 session.prompt capability is unavailable")
+
+  const host = createOpenCode2HostContract({
+    directory: options.directory,
+    subscribe: () => ctx.event.subscribe(),
+    sendPrompt: (request) => ctx.session.prompt(promptRequest(request)),
+    onEvent: options.onEvent,
+    onError: options.onError,
+  })
+
+  return Object.freeze({
+    start: () => host.start(),
+    prompt: (request) => host.prompt(request),
+    dispose: (reason = "runtime-adapter-disposed") => host.dispose(reason),
+    runtimeManager: host.runtimeManager,
+    isStarted: host.isStarted,
+    isDisposed: host.isDisposed,
+    isHostDisposed: host.isHostDisposed,
+  })
+}


### PR DESCRIPTION
Builds on the V2 host lifecycle already present on main. Isolates exact Promise transport, explicitly consumes event.subscribe as an async stream, disposes command.transform registrations on partial/full cleanup, preserves cleanup in the real-host probe, and adds an SSE/prompt/cleanup contract test. Stable V1 runtime and generated src/index.js are unchanged.