### PR TITLE
feat: add OpenCode 2 loop control commands

### DIFF
--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -68,8 +68,9 @@ try {
   assert.equal(removed.count, 1)
   assert.equal((await readState()).jobs.length, 1)
 
-  const cleared = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-clear", sessionID, directory, arguments: "" })
+  const cleared = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-clear", sessionID, directory, arguments: "missing-target-is-ignored" })
   assert.equal(cleared.count, 1)
+  assert.equal(cleared.target, "all")
   assert.equal((await readState()).jobs.length, 0)
 
   console.log("OpenCode 2 prompt runtime contract passed")

--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -30,6 +30,19 @@ try {
   assert.equal(state.jobs[0].runCount, 1)
   assert.equal(state.jobs[0].enabled, true)
 
+  const paused = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-pause", sessionID, directory, arguments: "" })
+  assert.equal(paused.count, 1)
+  state = await readState()
+  assert.equal(state.jobs[0].paused, true)
+  assert.equal((await runtime.onEvent({ kind: "session", action: "idle", sessionID, directory })).dispatched, false)
+  assert.equal(prompts.length, 1)
+
+  const resumed = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-resume", sessionID, directory, arguments: "" })
+  assert.equal(resumed.count, 1)
+  state = await readState()
+  assert.equal(state.jobs[0].paused, false)
+  assert.equal(state.jobs[0].lastRunAt, 0)
+
   assert.equal((await runtime.onEvent({ kind: "session", action: "idle", sessionID, directory })).dispatched, true)
   state = await readState()
   assert.equal(state.jobs[0].runCount, 2)
@@ -46,6 +59,18 @@ try {
   assert.equal(command.accepted, false)
   assert.ok(command.blockers.includes("kind"))
   assert.equal((await readState()).jobs.length, 1)
+
+  const named = await runtime.onEvent({ kind: "command", action: "executed", name: "loop", sessionID, directory, arguments: "0s --name keep --multi keep working" })
+  assert.equal(named.accepted, true)
+  assert.equal((await readState()).jobs.length, 2)
+
+  const removed = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-stop", sessionID, directory, arguments: "keep" })
+  assert.equal(removed.count, 1)
+  assert.equal((await readState()).jobs.length, 1)
+
+  const cleared = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-clear", sessionID, directory, arguments: "" })
+  assert.equal(cleared.count, 1)
+  assert.equal((await readState()).jobs.length, 0)
 
   console.log("OpenCode 2 prompt runtime contract passed")
 } finally {

--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -11,7 +11,12 @@ const runtime = createOpenCode2PromptRuntime({ prompt: async (request) => { prom
 
 async function readState() {
   const file = path.join(directory, ".opencode", "opencode-loop", `${sessionID}.json`)
-  return JSON.parse(await readFile(file, "utf8"))
+  try {
+    return JSON.parse(await readFile(file, "utf8"))
+  } catch (error) {
+    if (error?.code === "ENOENT") return { jobs: [] }
+    throw error
+  }
 }
 
 try {

--- a/src/source/opencode2/prompt-runtime.js
+++ b/src/source/opencode2/prompt-runtime.js
@@ -88,12 +88,12 @@ export function createOpenCode2PromptRuntime(options = {}) {
     return { handled: true, accepted: true, count, target }
   }
 
-  async function stopPromptLoops(event) {
+  async function stopPromptLoops(event, forcedTarget) {
     const directory = directoryFrom(event)
     const sessionID = String(event?.sessionID || "").trim()
     if (!directory || !sessionID) return { handled: false, reason: "missing-scope" }
 
-    const target = commandTarget(event)
+    const target = forcedTarget || commandTarget(event)
     if (target.toLowerCase() === "all") {
       const state = await readState(directory, sessionID)
       const count = (state.jobs || []).length
@@ -137,7 +137,8 @@ export function createOpenCode2PromptRuntime(options = {}) {
       if (event?.name === "loop") return addPromptLoop(event)
       if (event?.name === "loop-pause") return updatePromptLoops(event, (job) => ({ ...job, paused: true }))
       if (event?.name === "loop-resume") return updatePromptLoops(event, (job) => ({ ...job, paused: false, lastRunAt: 0 }))
-      if (["loop-stop", "loop-remove", "loop-clear"].includes(event?.name)) return stopPromptLoops(event)
+      if (["loop-stop", "loop-remove"].includes(event?.name)) return stopPromptLoops(event)
+      if (event?.name === "loop-clear") return stopPromptLoops(event, "all")
     }
     if (event?.kind === "session" && event?.action === "idle") {
       return runIdlePrompt(event)

--- a/src/source/opencode2/prompt-runtime.js
+++ b/src/source/opencode2/prompt-runtime.js
@@ -1,6 +1,6 @@
 import { parseLoopArgs } from "../core/args.js"
-import { actionKind, decoratePrompt } from "../core/jobs.js"
-import { readState, writeState } from "../core/state.js"
+import { actionKind, decoratePrompt, matchJob } from "../core/jobs.js"
+import { readState, removeState, writeState } from "../core/state.js"
 
 export const OPENCODE_LOOP_V2_PROMPT_RUNTIME = "prompt-zero-interval"
 export const OPENCODE_LOOP_V2_PROMPT_PREFIX = "AUTONOMOUS OPENCODE LOOP ITERATION. Continue the configured task now. Do not explain the /loop command. Do not search for documentation about this plugin. Do not create scheduler files. Do not ask questions. Make reasonable assumptions and work directly."
@@ -40,6 +40,10 @@ function promptText(job) {
   return `${OPENCODE_LOOP_V2_PROMPT_PREFIX}\n\n${decoratePrompt(job)}`
 }
 
+function commandTarget(event, fallback = "all") {
+  return String(event?.arguments || "").trim() || fallback
+}
+
 export function createOpenCode2PromptRuntime(options = {}) {
   if (typeof options.prompt !== "function") throw new TypeError("V2 prompt runtime requires prompt()")
 
@@ -67,6 +71,43 @@ export function createOpenCode2PromptRuntime(options = {}) {
     return { handled: true, accepted: true, job: parsed.job }
   }
 
+  async function updatePromptLoops(event, updater) {
+    const directory = directoryFrom(event)
+    const sessionID = String(event?.sessionID || "").trim()
+    if (!directory || !sessionID) return { handled: false, reason: "missing-scope" }
+
+    const target = commandTarget(event)
+    const state = await readState(directory, sessionID)
+    let count = 0
+    state.jobs = (state.jobs || []).map((job, index) => {
+      if (!matchJob(job, target, index)) return job
+      count += 1
+      return updater(job)
+    })
+    await writeState(directory, sessionID, state)
+    return { handled: true, accepted: true, count, target }
+  }
+
+  async function stopPromptLoops(event) {
+    const directory = directoryFrom(event)
+    const sessionID = String(event?.sessionID || "").trim()
+    if (!directory || !sessionID) return { handled: false, reason: "missing-scope" }
+
+    const target = commandTarget(event)
+    if (target.toLowerCase() === "all") {
+      const state = await readState(directory, sessionID)
+      const count = (state.jobs || []).length
+      await removeState(directory, sessionID)
+      return { handled: true, accepted: true, count, target }
+    }
+
+    const state = await readState(directory, sessionID)
+    const before = (state.jobs || []).length
+    state.jobs = (state.jobs || []).filter((job, index) => !matchJob(job, target, index))
+    await writeState(directory, sessionID, state)
+    return { handled: true, accepted: true, count: before - state.jobs.length, target }
+  }
+
   async function runIdlePrompt(event) {
     const directory = directoryFrom(event)
     const sessionID = String(event?.sessionID || "").trim()
@@ -92,8 +133,11 @@ export function createOpenCode2PromptRuntime(options = {}) {
   }
 
   async function onEvent(event) {
-    if (event?.kind === "command" && event?.action === "executed" && event?.name === "loop") {
-      return addPromptLoop(event)
+    if (event?.kind === "command" && event?.action === "executed") {
+      if (event?.name === "loop") return addPromptLoop(event)
+      if (event?.name === "loop-pause") return updatePromptLoops(event, (job) => ({ ...job, paused: true }))
+      if (event?.name === "loop-resume") return updatePromptLoops(event, (job) => ({ ...job, paused: false, lastRunAt: 0 }))
+      if (["loop-stop", "loop-remove", "loop-clear"].includes(event?.name)) return stopPromptLoops(event)
     }
     if (event?.kind === "session" && event?.action === "idle") {
       return runIdlePrompt(event)
@@ -101,5 +145,5 @@ export function createOpenCode2PromptRuntime(options = {}) {
     return { handled: false }
   }
 
-  return Object.freeze({ onEvent, addPromptLoop, runIdlePrompt })
+  return Object.freeze({ onEvent, addPromptLoop, updatePromptLoops, stopPromptLoops, runIdlePrompt })
 }


### PR DESCRIPTION
Adds the next narrow OpenCode 2 runtime slice without changing the V1 generated runtime.

- support `loop-pause` and `loop-resume` in the V2 prompt runtime
- support `loop-stop`, `loop-remove`, and `loop-clear`
- preserve V1 target semantics (`all`, name/id/index)
- add contract coverage for pause -> idle suppression -> resume -> dispatch -> named stop -> clear

V2 remains limited to zero-interval prompt jobs; no scheduler/interval behavior is added here.