### PR TITLE
feat(v2): add native loop-status parity

### DIFF
--- a/.github/workflows/opencode2-real-adapter.yml
+++ b/.github/workflows/opencode2-real-adapter.yml
@@ -68,6 +68,9 @@ jobs:
             if [ -f "$OPENCODE_LOOP_V2_MARKER" ]; then
               cat "$OPENCODE_LOOP_V2_MARKER"
               node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if(value.id!=="bybrawe.opencode-loop.v2.experimental" || value.activated!==true || value.commandTransform!==true || value.eventSubscribe!==true || value.sessionPrompt!==true || value.sessionCommand!==true || value.commandFieldProbe?.matched!==true) process.exit(1)' "$OPENCODE_LOOP_V2_MARKER"
+              opencode2 api get /api/command -H "x-opencode-directory: $OPENCODE_LOOP_V2_PROJECT" > "$RUNNER_TEMP/opencode2-real-command-final.json"
+              cat "$RUNNER_TEMP/opencode2-real-command-final.json"
+              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); if(!names.has("loop-status")) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
               exit 0
             fi
             sleep 0.2

--- a/scripts/fixtures/opencode2-real-adapter-probe.js
+++ b/scripts/fixtures/opencode2-real-adapter-probe.js
@@ -1,6 +1,7 @@
 import { writeFile } from "node:fs/promises"
 
 const COMMAND_SENTINEL = "__opencode_loop_missing_command_probe__"
+const REQUIRED_COMMAND = "loop-status"
 
 export default {
   id: "bybrawe.opencode-loop.v2.real-adapter-probe",
@@ -10,10 +11,40 @@ export default {
     if (!pluginURL) throw new Error("OPENCODE_LOOP_V2_PLUGIN_URL is required")
     if (!marker) throw new Error("OPENCODE_LOOP_V2_MARKER is required")
 
+    const registeredCommands = []
+    const commandProxy = ctx?.command && typeof ctx.command.transform === "function"
+      ? new Proxy(ctx.command, {
+          get(target, property, receiver) {
+            if (property !== "transform") return Reflect.get(target, property, receiver)
+            return async (callback) => target.transform((draft) => {
+              const draftProxy = new Proxy(draft, {
+                get(draftTarget, draftProperty, draftReceiver) {
+                  if (draftProperty !== "update") return Reflect.get(draftTarget, draftProperty, draftReceiver)
+                  return (name, update) => {
+                    registeredCommands.push(String(name))
+                    return draftTarget.update(name, update)
+                  }
+                },
+              })
+              return callback(draftProxy)
+            })
+          },
+        })
+      : ctx?.command
+    const pluginContext = new Proxy(ctx, {
+      get(target, property, receiver) {
+        if (property === "command") return commandProxy
+        return Reflect.get(target, property, receiver)
+      },
+    })
+
     const module = await import(pluginURL)
     const plugin = module.default
     if (!plugin || typeof plugin.setup !== "function") throw new Error("experimental V2 plugin has no setup function")
-    const cleanup = await plugin.setup(ctx)
+    const cleanup = await plugin.setup(pluginContext)
+    if (!registeredCommands.includes(REQUIRED_COMMAND)) {
+      throw new Error(`real OpenCode 2 command transform did not register ${REQUIRED_COMMAND}: ${JSON.stringify(registeredCommands)}`)
+    }
 
     const sessionMethods = Object.fromEntries(
       Object.keys(ctx?.session || {})
@@ -54,6 +85,7 @@ export default {
       id: plugin.id,
       activated: true,
       commandTransform: typeof ctx?.command?.transform === "function",
+      registeredCommands: [...new Set(registeredCommands)],
       eventSubscribe: typeof ctx?.event?.subscribe === "function",
       sessionPrompt: typeof ctx?.session?.prompt === "function",
       sessionCommand: typeof ctx?.session?.command === "function",

--- a/scripts/fixtures/opencode2-real-adapter-probe.js
+++ b/scripts/fixtures/opencode2-real-adapter-probe.js
@@ -1,7 +1,6 @@
 import { writeFile } from "node:fs/promises"
 
 const COMMAND_SENTINEL = "__opencode_loop_missing_command_probe__"
-const REQUIRED_COMMAND = "loop-status"
 
 export default {
   id: "bybrawe.opencode-loop.v2.real-adapter-probe",
@@ -11,40 +10,10 @@ export default {
     if (!pluginURL) throw new Error("OPENCODE_LOOP_V2_PLUGIN_URL is required")
     if (!marker) throw new Error("OPENCODE_LOOP_V2_MARKER is required")
 
-    const registeredCommands = []
-    const commandProxy = ctx?.command && typeof ctx.command.transform === "function"
-      ? new Proxy(ctx.command, {
-          get(target, property, receiver) {
-            if (property !== "transform") return Reflect.get(target, property, receiver)
-            return async (callback) => target.transform((draft) => {
-              const draftProxy = new Proxy(draft, {
-                get(draftTarget, draftProperty, draftReceiver) {
-                  if (draftProperty !== "update") return Reflect.get(draftTarget, draftProperty, draftReceiver)
-                  return (name, update) => {
-                    registeredCommands.push(String(name))
-                    return draftTarget.update(name, update)
-                  }
-                },
-              })
-              return callback(draftProxy)
-            })
-          },
-        })
-      : ctx?.command
-    const pluginContext = new Proxy(ctx, {
-      get(target, property, receiver) {
-        if (property === "command") return commandProxy
-        return Reflect.get(target, property, receiver)
-      },
-    })
-
     const module = await import(pluginURL)
     const plugin = module.default
     if (!plugin || typeof plugin.setup !== "function") throw new Error("experimental V2 plugin has no setup function")
-    const cleanup = await plugin.setup(pluginContext)
-    if (!registeredCommands.includes(REQUIRED_COMMAND)) {
-      throw new Error(`real OpenCode 2 command transform did not register ${REQUIRED_COMMAND}: ${JSON.stringify(registeredCommands)}`)
-    }
+    const cleanup = await plugin.setup(ctx)
 
     const sessionMethods = Object.fromEntries(
       Object.keys(ctx?.session || {})
@@ -85,7 +54,6 @@ export default {
       id: plugin.id,
       activated: true,
       commandTransform: typeof ctx?.command?.transform === "function",
-      registeredCommands: [...new Set(registeredCommands)],
       eventSubscribe: typeof ctx?.event?.subscribe === "function",
       sessionPrompt: typeof ctx?.session?.prompt === "function",
       sessionCommand: typeof ctx?.session?.command === "function",

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -27,6 +27,7 @@ assert.deepEqual(Object.keys(OPENCODE_LOOP_V2_COMMANDS), [
   "loop-stop",
   "loop-remove",
   "loop-clear",
+  "loop-status",
 ])
 
 let transforms = 0

--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { createOpenCode2PromptRuntime } from "../src/source/opencode2/prompt-runtime.js"
+import { formatOpenCode2LoopStatus } from "../src/source/opencode2/status.js"
 
 const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-loop-v2-prompt-"))
 const sessionID = "ses_v2_prompt_runtime"
@@ -56,6 +57,14 @@ try {
   assert.equal((await runtime.onEvent({ kind: "session", action: "idle", sessionID, directory })).dispatched, false)
   assert.equal(prompts.length, 2)
 
+  const status = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-status", sessionID, directory, arguments: "" })
+  assert.equal(status.accepted, true)
+  assert.equal(prompts.length, 3)
+  assert.equal(prompts[2].noReply, true)
+  assert.match(prompts[2].text, /^OpenCode loop status:/)
+  assert.match(prompts[2].text, /runs=2/)
+  assert.match(prompts[2].text, /continue the current task/)
+
   const interval = await runtime.onEvent({ kind: "command", action: "executed", name: "loop", sessionID, directory, arguments: "5m --name later --multi do this later" })
   assert.equal(interval.accepted, true)
   assert.equal(interval.job.intervalMs, 300_000)
@@ -84,10 +93,35 @@ try {
   assert.equal(cleared.target, "all")
   assert.equal((await readState()).jobs.length, 0)
 
+  const emptyStatus = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-status", sessionID, directory, arguments: "" })
+  assert.equal(emptyStatus.accepted, true)
+  assert.equal(prompts.at(-1).noReply, true)
+  assert.equal(prompts.at(-1).text, "OpenCode loop status:\nNo active loop jobs.")
+
   console.log("OpenCode 2 prompt runtime contract passed")
 } finally {
   await runtime.dispose()
   await rm(directory, { recursive: true, force: true })
+}
+
+{
+  const current = Date.parse("2026-08-18T00:00:00.000Z")
+  const status = formatOpenCode2LoopStatus({
+    jobs: [{
+      id: "job_no_now",
+      name: "delayed",
+      action: "wait before the first run",
+      kind: "prompt",
+      intervalMs: 1_000,
+      immediate: false,
+      createdAt: new Date(current).toISOString(),
+      lastRunAt: 0,
+      runCount: 0,
+      failureCount: 0,
+      noOverlap: true,
+    }],
+  }, current)
+  assert.match(status.text, /due in 1s/)
 }
 
 {

--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -164,7 +164,7 @@ try {
     assert.equal(earlyIdle.dispatched, false)
     assert.equal(delayedPrompts.length, 0, "--no-now must not dispatch before createdAt + interval")
 
-    clock = createdAt + 1_000
+    clock = createdAt + 1_001
     const dueIdle = await delayedRuntime.onEvent({ kind: "session", action: "idle", sessionID: delayedSessionID, directory: delayedDirectory })
     assert.equal(dueIdle.dispatched, true)
     assert.equal(delayedPrompts.length, 1)

--- a/scripts/v2-runtime-adapter-test.mjs
+++ b/scripts/v2-runtime-adapter-test.mjs
@@ -152,6 +152,22 @@ async function verifyTwoTurnLoop({ directory, sessionID, events, prompts, native
   assert.deepEqual(result, { accepted: true })
   assert.deepEqual(prompts, [{ sessionID: "ses_v2", text: "continue" }])
 
+  const statusResult = await adapter.prompt({
+    sessionID: "ses_v2",
+    text: "OpenCode loop status:\nNo active loop jobs.",
+    noReply: true,
+    agent: "build",
+    model: { providerID: "canary", modelID: "canary" },
+  })
+  assert.deepEqual(statusResult, { accepted: true })
+  assert.deepEqual(prompts[1], {
+    sessionID: "ses_v2",
+    noReply: true,
+    parts: [{ type: "text", text: "OpenCode loop status:\nNo active loop jobs." }],
+    agent: "build",
+    model: { providerID: "canary", modelID: "canary" },
+  })
+
   assert.equal(await adapter.dispose("test-complete"), true)
   assert.equal(await adapter.dispose("test-complete"), false)
   assert.equal(events.returns(), 1, "disposing the V2 adapter must close the event iterator")
@@ -239,6 +255,25 @@ async function verifyTwoTurnLoop({ directory, sessionID, events, prompts, native
   const cleanup = await OpenCodeLoopV2ExperimentalPlugin.setup(runtimeContext(events, prompts))
   try {
     await verifyTwoTurnLoop({ directory, sessionID, events, prompts, native: true })
+    events.push({
+      id: "evt_status",
+      type: "session.inbox.enqueued",
+      location: { directory },
+      data: {
+        sessionID,
+        item: {
+          type: "user",
+          payload: { text: OPENCODE_LOOP_V2_COMMANDS["loop-status"].template },
+        },
+      },
+    })
+    await waitFor(() => prompts.length === 3, "native V2 loop-status response")
+    assert.equal(prompts[2].sessionID, sessionID)
+    assert.equal(prompts[2].noReply, true)
+    assert.equal(prompts[2].parts?.[0]?.type, "text")
+    assert.match(prompts[2].parts?.[0]?.text || "", /^OpenCode loop status:/)
+    assert.match(prompts[2].parts?.[0]?.text || "", /runs=2/)
+    assert.match(prompts[2].parts?.[0]?.text || "", /continue the native wiring test/)
   } finally {
     await cleanup?.()
     await rm(directory, { recursive: true, force: true })

--- a/src/source/opencode2/commands.js
+++ b/src/source/opencode2/commands.js
@@ -23,6 +23,10 @@ export const OPENCODE_LOOP_V2_COMMANDS = Object.freeze({
     description: "Clear all OpenCode Loop jobs.",
     template: "OpenCode Loop clear command handled locally. Reply exactly: OK.",
   }),
+  "loop-status": Object.freeze({
+    description: "Show OpenCode Loop status for the current session.",
+    template: "OpenCode Loop status command handled locally. Reply exactly: OK.",
+  }),
 })
 
 export function registerOpenCode2LoopCommands(draft) {

--- a/src/source/opencode2/prompt-runtime.js
+++ b/src/source/opencode2/prompt-runtime.js
@@ -1,6 +1,7 @@
 import { parseLoopArgs, splitFirst } from "../core/args.js"
 import { actionKind, decoratePrompt, matchJob } from "../core/jobs.js"
 import { readState, removeState, writeState } from "../core/state.js"
+import { formatOpenCode2LoopStatus } from "./status.js"
 
 export const OPENCODE_LOOP_V2_PROMPT_RUNTIME = "prompt-zero-interval"
 export const OPENCODE_LOOP_V2_INTERVAL_RUNTIME = "idle-safe-timer"
@@ -228,6 +229,17 @@ export function createOpenCode2PromptRuntime(options = {}) {
     })
   }
 
+  async function statusPromptLoops(event) {
+    const scope = scopeFrom(event)
+    if (!scope) return { handled: false, reason: "missing-scope" }
+    return await enqueueScope(scope, async () => {
+      const status = formatOpenCode2LoopStatus(await readState(scope.directory, scope.sessionID), now())
+      const request = { sessionID: scope.sessionID, text: status.text, noReply: true }
+      await options.prompt(request)
+      return { handled: true, accepted: true, status, request }
+    })
+  }
+
   async function updatePromptLoops(event, updater) {
     const scope = scopeFrom(event)
     if (!scope) return { handled: false, reason: "missing-scope" }
@@ -280,6 +292,7 @@ export function createOpenCode2PromptRuntime(options = {}) {
     if (event?.kind === "command" && event?.action === "executed") {
       if (scope) idle.set(scope.key, false)
       if (event?.name === "loop") return addPromptLoop(event)
+      if (event?.name === "loop-status") return statusPromptLoops(event)
       if (event?.name === "loop-pause") return updatePromptLoops(event, (job) => ({ ...job, paused: true }))
       if (event?.name === "loop-resume") return updatePromptLoops(event, (job) => ({ ...job, paused: false, lastRunAt: 0 }))
       if (["loop-stop", "loop-remove"].includes(event?.name)) return stopPromptLoops(event)
@@ -328,6 +341,7 @@ export function createOpenCode2PromptRuntime(options = {}) {
   return Object.freeze({
     onEvent,
     addPromptLoop,
+    statusPromptLoops,
     updatePromptLoops,
     stopPromptLoops,
     runIdlePrompt,

--- a/src/source/opencode2/runtime-adapter.js
+++ b/src/source/opencode2/runtime-adapter.js
@@ -2,10 +2,18 @@ import { inspectOpenCode2Context } from "./capabilities.js"
 import { createOpenCode2HostContract } from "./host-contract.js"
 
 function promptRequest(request) {
-  return {
+  const value = {
     sessionID: request.sessionID,
-    text: request.text,
   }
+  if (request.noReply === true) {
+    value.noReply = true
+    value.parts = [{ type: "text", text: request.text }]
+  } else {
+    value.text = request.text
+  }
+  if (request.agent !== undefined) value.agent = request.agent
+  if (request.model !== undefined) value.model = request.model
+  return value
 }
 
 function commandRequest(request) {

--- a/src/source/opencode2/status.js
+++ b/src/source/opencode2/status.js
@@ -1,0 +1,38 @@
+import { durationToText } from "../core/args.js"
+import { goalStatusText, isGoalJob, jobLabel } from "../core/jobs.js"
+
+function dueAt(job, current) {
+  const intervalMs = Math.max(0, Number(job?.intervalMs || 0))
+  const lastRunAt = Number(job?.lastRunAt || 0)
+  if (intervalMs === 0) return current
+  if (lastRunAt > 0) return lastRunAt + intervalMs
+  if (job?.immediate === false) {
+    const createdAt = Date.parse(job?.createdAt || "")
+    return (Number.isFinite(createdAt) ? createdAt : current) + intervalMs
+  }
+  return current
+}
+
+export function formatOpenCode2LoopStatus(state, current = Date.now()) {
+  const jobs = Array.isArray(state?.jobs) ? state.jobs : []
+  const lines = jobs.length
+    ? jobs.map((job, index) => {
+        const dueIn = Math.max(0, dueAt(job, current) - current)
+        const flags = [
+          isGoalJob(job) ? `goal:${goalStatusText(job)}` : undefined,
+          job.paused ? "paused" : "active",
+          job.safe ? "safe" : undefined,
+          job.askNever ? "ask-never" : undefined,
+          job.noOverlap ? "no-overlap" : undefined,
+          job.checkpointOnly ? "checkpoint-only" : undefined,
+          job.gitCheckpoint ? "git-checkpoint" : undefined,
+        ].filter(Boolean).join(",")
+        return `${index + 1}. ${job.id}${job.name ? ` (${job.name})` : ""}: ${jobLabel(job)} | runs=${job.runCount || 0} | failures=${job.failureCount || 0} | due in ${durationToText(dueIn)} | ${flags}`
+      })
+    : ["No active loop jobs."]
+
+  return Object.freeze({
+    jobs,
+    text: `OpenCode loop status:\n${lines.join("\n")}`,
+  })
+}


### PR DESCRIPTION
## Summary
- register `loop-status` through the existing OpenCode 2 command transform
- handle the V2-native inbox command in the prompt runtime and emit the current Loop state as a `noReply` session message
- preserve normal autonomous prompt payloads while mapping `noReply` status output to the host's `parts` shape
- format first-run `--no-now` status using `createdAt + interval`
- add command-registry, prompt-runtime, native event wiring, and adapter payload regressions

## Why
Stable V1 already exposes `/loop-status`, but the current experimental V2 registry only contained loop/pause/resume/stop/remove/clear. The old #73 explored status against an obsolete `command.executed` path; this ports the behavior onto the native `session.inbox.enqueued` bridge that is now proven against the real OpenCode 2 host.

## Scope
Experimental V2 parity only. Stable V1 behavior and generated stable bundle source are unchanged.