### PR TITLE
feat(v2): add targeted loop-now parity

### DIFF
--- a/.github/workflows/opencode2-real-adapter.yml
+++ b/.github/workflows/opencode2-real-adapter.yml
@@ -70,7 +70,7 @@ jobs:
               node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if(value.id!=="bybrawe.opencode-loop.v2.experimental" || value.activated!==true || value.commandTransform!==true || value.eventSubscribe!==true || value.sessionPrompt!==true || value.sessionCommand!==true || value.commandFieldProbe?.matched!==true) process.exit(1)' "$OPENCODE_LOOP_V2_MARKER"
               opencode2 api get /api/command -H "x-opencode-directory: $OPENCODE_LOOP_V2_PROJECT" > "$RUNNER_TEMP/opencode2-real-command-final.json"
               cat "$RUNNER_TEMP/opencode2-real-command-final.json"
-              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); if(!names.has("loop-status")) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
+              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); for (const required of ["loop-status","loop-now"]) if(!names.has(required)) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
               exit 0
             fi
             sleep 0.2

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import plugin, {
   OPENCODE_LOOP_V2_COMMANDS,
   OPENCODE_LOOP_V2_PLUGIN_ID,
+  parseOpenCode2LoopCommandText,
 } from "../src/source/opencode2/experimental.js"
 import {
   OPENCODE_LOOP_V2_COMMAND_SOURCE,
@@ -30,6 +31,10 @@ assert.deepEqual(Object.keys(OPENCODE_LOOP_V2_COMMANDS), [
   "loop-status",
   "loop-now",
 ])
+assert.deepEqual(
+  parseOpenCode2LoopCommandText(`${OPENCODE_LOOP_V2_COMMANDS["loop-now"].template}\n\nsecond`),
+  { name: "loop-now", arguments: "second" },
+)
 
 let transforms = 0
 let registered

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -28,6 +28,7 @@ assert.deepEqual(Object.keys(OPENCODE_LOOP_V2_COMMANDS), [
   "loop-remove",
   "loop-clear",
   "loop-status",
+  "loop-now",
 ])
 
 let transforms = 0

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -2,8 +2,8 @@ import assert from "node:assert/strict"
 import plugin, {
   OPENCODE_LOOP_V2_COMMANDS,
   OPENCODE_LOOP_V2_PLUGIN_ID,
-  parseOpenCode2LoopCommandText,
 } from "../src/source/opencode2/experimental.js"
+import { parseOpenCode2LoopCommandText } from "../src/source/opencode2/commands.js"
 import {
   OPENCODE_LOOP_V2_COMMAND_SOURCE,
   OPENCODE_LOOP_V2_HOST_REQUIREMENTS,

--- a/scripts/v2-prompt-runtime-test.mjs
+++ b/scripts/v2-prompt-runtime-test.mjs
@@ -177,4 +177,91 @@ try {
   }
 }
 
-console.log("OpenCode 2 --no-now first-run contract passed")
+{
+  const nowDirectory = await mkdtemp(path.join(os.tmpdir(), "opencode-loop-v2-run-now-"))
+  const nowSessionID = "ses_v2_run_now"
+  const nowPrompts = []
+  const clock = Date.parse("2026-08-18T00:00:00.000Z")
+  const nowRuntime = createOpenCode2PromptRuntime({
+    prompt: async (request) => { nowPrompts.push(request) },
+    now: () => clock,
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {},
+  })
+  const nowFile = path.join(nowDirectory, ".opencode", "opencode-loop", `${nowSessionID}.json`)
+
+  try {
+    await nowRuntime.onEvent({
+      kind: "command",
+      action: "executed",
+      name: "loop",
+      sessionID: nowSessionID,
+      directory: nowDirectory,
+      arguments: "0s --name first --multi --max-runs 1 first naturally due job",
+    })
+    await nowRuntime.onEvent({
+      kind: "command",
+      action: "executed",
+      name: "loop",
+      sessionID: nowSessionID,
+      directory: nowDirectory,
+      arguments: "10m --no-now --name second --multi --max-runs 1 second forced job",
+    })
+    const paused = await nowRuntime.onEvent({
+      kind: "command",
+      action: "executed",
+      name: "loop-pause",
+      sessionID: nowSessionID,
+      directory: nowDirectory,
+      arguments: "second",
+    })
+    assert.equal(paused.count, 1)
+
+    const missing = await nowRuntime.onEvent({
+      kind: "command",
+      action: "executed",
+      name: "loop-now",
+      sessionID: nowSessionID,
+      directory: nowDirectory,
+      arguments: "missing",
+    })
+    assert.equal(missing.count, 0)
+
+    const requested = await nowRuntime.onEvent({
+      kind: "command",
+      action: "executed",
+      name: "loop-now",
+      sessionID: nowSessionID,
+      directory: nowDirectory,
+      arguments: "second",
+    })
+    assert.equal(requested.count, 1)
+    assert.equal(requested.target, "second")
+
+    let state = JSON.parse(await readFile(nowFile, "utf8"))
+    const first = state.jobs.find((job) => job.name === "first")
+    const second = state.jobs.find((job) => job.name === "second")
+    assert.equal(first.runNowRequestedAt, undefined)
+    assert.equal(second.paused, false)
+    assert.equal(second.runNowRequestedAt, clock)
+    const status = formatOpenCode2LoopStatus(state, clock)
+    assert.match(status.text, /second forced job[^\n]*due in every idle[^\n]*run-now/)
+
+    const forcedIdle = await nowRuntime.onEvent({ kind: "session", action: "idle", sessionID: nowSessionID, directory: nowDirectory })
+    assert.equal(forcedIdle.dispatched, true)
+    assert.match(nowPrompts[0].text, /second forced job/)
+    state = JSON.parse(await readFile(nowFile, "utf8"))
+    assert.equal(state.jobs.find((job) => job.name === "second").runNowRequestedAt, undefined)
+    assert.equal(state.jobs.find((job) => job.name === "second").runCount, 1)
+    assert.equal(state.jobs.find((job) => job.name === "first").runCount, 0)
+
+    const naturalIdle = await nowRuntime.onEvent({ kind: "session", action: "idle", sessionID: nowSessionID, directory: nowDirectory })
+    assert.equal(naturalIdle.dispatched, true)
+    assert.match(nowPrompts[1].text, /first naturally due job/)
+  } finally {
+    await nowRuntime.dispose()
+    await rm(nowDirectory, { recursive: true, force: true })
+  }
+}
+
+console.log("OpenCode 2 --no-now and loop-now contracts passed")

--- a/src/source/opencode2/commands.js
+++ b/src/source/opencode2/commands.js
@@ -27,6 +27,10 @@ export const OPENCODE_LOOP_V2_COMMANDS = Object.freeze({
     description: "Show OpenCode Loop status for the current session.",
     template: "OpenCode Loop status command handled locally. Reply exactly: OK.",
   }),
+  "loop-now": Object.freeze({
+    description: "Run matching OpenCode Loop jobs on the next idle boundary.",
+    template: "OpenCode Loop run-now command handled locally. Reply exactly: OK.",
+  }),
 })
 
 export function registerOpenCode2LoopCommands(draft) {

--- a/src/source/opencode2/prompt-runtime.js
+++ b/src/source/opencode2/prompt-runtime.js
@@ -63,7 +63,12 @@ function scopeFrom(event) {
   return { directory, sessionID, key: `${directory}\u0000${sessionID}` }
 }
 
+function runNowRequested(job) {
+  return Number(job?.runNowRequestedAt || 0) > 0
+}
+
 function dueAt(job, current) {
+  if (runNowRequested(job)) return current
   const intervalMs = Math.max(0, Number(job?.intervalMs || 0))
   const lastRunAt = Number(job?.lastRunAt || 0)
   if (intervalMs === 0) return current
@@ -185,12 +190,14 @@ export function createOpenCode2PromptRuntime(options = {}) {
   async function runDueAction(scope) {
     const state = await readState(scope.directory, scope.sessionID)
     const current = now()
-    const job = (state.jobs || []).find((candidate) => eligibleRuntimeJob(candidate) && dueAt(candidate, current) <= current)
+    const due = (state.jobs || []).filter((candidate) => eligibleRuntimeJob(candidate) && dueAt(candidate, current) <= current)
+    const job = due.find(runNowRequested) || due[0]
     if (!job) {
       await scheduleScope(scope)
       return { handled: true, dispatched: false }
     }
 
+    delete job.runNowRequestedAt
     job.lastRunAt = current
     job.runCount = (job.runCount || 0) + 1
     if (job.maxRuns > 0 && job.runCount >= job.maxRuns) job.enabled = false
@@ -237,6 +244,27 @@ export function createOpenCode2PromptRuntime(options = {}) {
       const request = { sessionID: scope.sessionID, text: status.text, noReply: true }
       await options.prompt(request)
       return { handled: true, accepted: true, status, request }
+    })
+  }
+
+  async function runPromptLoopsNow(event) {
+    const scope = scopeFrom(event)
+    if (!scope) return { handled: false, reason: "missing-scope" }
+    return await enqueueScope(scope, async () => {
+      const target = commandTarget(event)
+      const state = await readState(scope.directory, scope.sessionID)
+      const requestedAt = Math.max(1, now())
+      let count = 0
+      state.jobs = (state.jobs || []).map((job, index) => {
+        if (!matchJob(job, target, index)) return job
+        const resumed = { ...job, paused: false }
+        if (!eligibleRuntimeJob(resumed)) return job
+        count += 1
+        return { ...resumed, runNowRequestedAt: requestedAt }
+      })
+      await writeState(scope.directory, scope.sessionID, state)
+      await scheduleScope(scope)
+      return { handled: true, accepted: true, count, target, requestedAt: count ? requestedAt : undefined }
     })
   }
 
@@ -293,6 +321,7 @@ export function createOpenCode2PromptRuntime(options = {}) {
       if (scope) idle.set(scope.key, false)
       if (event?.name === "loop") return addPromptLoop(event)
       if (event?.name === "loop-status") return statusPromptLoops(event)
+      if (event?.name === "loop-now") return runPromptLoopsNow(event)
       if (event?.name === "loop-pause") return updatePromptLoops(event, (job) => ({ ...job, paused: true }))
       if (event?.name === "loop-resume") return updatePromptLoops(event, (job) => ({ ...job, paused: false, lastRunAt: 0 }))
       if (["loop-stop", "loop-remove"].includes(event?.name)) return stopPromptLoops(event)
@@ -342,6 +371,7 @@ export function createOpenCode2PromptRuntime(options = {}) {
     onEvent,
     addPromptLoop,
     statusPromptLoops,
+    runPromptLoopsNow,
     updatePromptLoops,
     stopPromptLoops,
     runIdlePrompt,

--- a/src/source/opencode2/status.js
+++ b/src/source/opencode2/status.js
@@ -2,6 +2,7 @@ import { durationToText } from "../core/args.js"
 import { goalStatusText, isGoalJob, jobLabel } from "../core/jobs.js"
 
 function dueAt(job, current) {
+  if (Number(job?.runNowRequestedAt || 0) > 0) return current
   const intervalMs = Math.max(0, Number(job?.intervalMs || 0))
   const lastRunAt = Number(job?.lastRunAt || 0)
   if (intervalMs === 0) return current
@@ -21,6 +22,7 @@ export function formatOpenCode2LoopStatus(state, current = Date.now()) {
         const flags = [
           isGoalJob(job) ? `goal:${goalStatusText(job)}` : undefined,
           job.paused ? "paused" : "active",
+          Number(job.runNowRequestedAt || 0) > 0 ? "run-now" : undefined,
           job.safe ? "safe" : undefined,
           job.askNever ? "ask-never" : undefined,
           job.noOverlap ? "no-overlap" : undefined,


### PR DESCRIPTION
## Summary
- register `loop-now` in the experimental OpenCode 2 command registry
- persist a one-shot run-now request on matching active jobs instead of dispatching re-entrantly while the command turn is still busy
- prioritize the requested job over other naturally-due jobs at the next idle boundary, then consume the marker before dispatch
- unpause matching jobs and preserve `--no-now` interval semantics outside the explicit run-now request
- show pending run-now jobs as due now in V2 status
- gate `loop-now` in the real `@next` command registry and add parser/target-priority regressions

## Why
Stable V1 exposes `/loop-now`, while V2 did not. The V2-native event model emits the local command through the inbox and reaches an execution-success idle boundary afterward, so a persisted one-shot marker keeps the operation idle-safe and target-specific without opening a model turn from inside the command handler.

## Scope
Experimental V2 parity only. A separate stable V1 edge involving `force:true` target selection/busy persistence was identified during review and is intentionally not mixed into this PR.