### PR TITLE
fix: report stable no-now due time correctly

### DIFF
--- a/scripts/loop-command-handlers-test.mjs
+++ b/scripts/loop-command-handlers-test.mjs
@@ -154,6 +154,22 @@ assert.throws(() => createLoopCommandHandlers({ clearActiveRun() {} }), /cancelD
 }
 
 {
+  const sessionID = "status-no-now"
+  const h = harness({
+    [sessionID]: {
+      jobs: [loopJob("delayed", {
+        intervalMs: 10_000,
+        lastRunAt: 0,
+        immediate: false,
+        createdAt: new Date(5_000).toISOString(),
+      })],
+    },
+  }, { now: () => 10_000 })
+  await h.handlers.statusLoop("/work", {}, sessionID)
+  assert.match(h.messages[0][2], /due in 5s/, "--no-now status must count the first interval from createdAt")
+}
+
+{
   const sessionID = "status-empty"
   const h = harness({ [sessionID]: { jobs: [] } })
   await h.handlers.statusLoop("/work", {}, sessionID)

--- a/src/index.js
+++ b/src/index.js
@@ -1698,7 +1698,12 @@ function createLoopCommandHandlers(options = {}) {
     const state = await readState2(directory, sessionID);
     const jobs = state.jobs || [];
     const lines = jobs.length ? jobs.map((job, index) => {
-      const dueIn = Number(job.runNowRequestedAt || 0) > 0 ? 0 : Math.max(0, job.intervalMs - (now2() - (job.lastRunAt || 0)));
+      const current = now2();
+      const intervalMs = Number(job.intervalMs || 0);
+      const lastRunAt = Number(job.lastRunAt || 0);
+      const createdAt = Date.parse(job.createdAt || "");
+      const dueAt = Number(job.runNowRequestedAt || 0) > 0 ? current : lastRunAt > 0 ? lastRunAt + intervalMs : job.immediate === false && Number.isFinite(createdAt) ? createdAt + intervalMs : current;
+      const dueIn = Math.max(0, dueAt - current);
       const flags = [isGoalJob(job) ? `goal:${goalStatusText(job)}` : undefined, job.paused ? "paused" : "active", Number(job.runNowRequestedAt || 0) > 0 ? "run-now" : undefined, job.safe ? "safe" : undefined, job.askNever ? "ask-never" : undefined, job.noOverlap ? "no-overlap" : undefined, job.checkpointOnly ? "checkpoint-only" : undefined, job.gitCheckpoint ? "git-checkpoint" : undefined].filter(Boolean).join(",");
       return `${index + 1}. ${job.id}${job.name ? ` (${job.name})` : ""}: ${jobLabel(job)} | runs=${job.runCount || 0} | failures=${job.failureCount || 0} | due in ${durationToText(dueIn)} | ${flags}`;
     }) : ["No active loop jobs."];

--- a/src/source/opencode/loop-commands.js
+++ b/src/source/opencode/loop-commands.js
@@ -89,7 +89,18 @@ export function createLoopCommandHandlers(options = {}) {
     const state = await readState(directory, sessionID)
     const jobs = state.jobs || []
     const lines = jobs.length ? jobs.map((job, index) => {
-      const dueIn = Number(job.runNowRequestedAt || 0) > 0 ? 0 : Math.max(0, job.intervalMs - (now() - (job.lastRunAt || 0)))
+      const current = now()
+      const intervalMs = Number(job.intervalMs || 0)
+      const lastRunAt = Number(job.lastRunAt || 0)
+      const createdAt = Date.parse(job.createdAt || "")
+      const dueAt = Number(job.runNowRequestedAt || 0) > 0
+        ? current
+        : lastRunAt > 0
+          ? lastRunAt + intervalMs
+          : job.immediate === false && Number.isFinite(createdAt)
+            ? createdAt + intervalMs
+            : current
+      const dueIn = Math.max(0, dueAt - current)
       const flags = [isGoalJob(job) ? `goal:${goalStatusText(job)}` : undefined, job.paused ? "paused" : "active", Number(job.runNowRequestedAt || 0) > 0 ? "run-now" : undefined, job.safe ? "safe" : undefined, job.askNever ? "ask-never" : undefined, job.noOverlap ? "no-overlap" : undefined, job.checkpointOnly ? "checkpoint-only" : undefined, job.gitCheckpoint ? "git-checkpoint" : undefined].filter(Boolean).join(",")
       return `${index + 1}. ${job.id}${job.name ? ` (${job.name})` : ""}: ${jobLabel(job)} | runs=${job.runCount || 0} | failures=${job.failureCount || 0} | due in ${durationToText(dueIn)} | ${flags}`
     }) : ["No active loop jobs."]


### PR DESCRIPTION
## Summary
- make stable `/loop-status` report the first `--no-now` due time from `createdAt + interval`
- preserve existing status semantics for completed runs and explicit run-now requests
- add deterministic command-handler coverage for the first delayed run
- regenerate committed `src/index.js` from the fixed stable source

## Why
After `--no-now` was fixed at the scheduler level, stable `/loop-status` still calculated a never-run job as `interval - (now - 0)`, which commonly displayed `due in 0s`. The runtime scheduler correctly waits from `createdAt`; status should report the same boundary.

## Scope
Stable status reporting only; no scheduler or dispatch behavior changes.