### PR TITLE
feat(v2): add conservative loop-help parity

### DIFF
--- a/.github/workflows/opencode2-real-adapter.yml
+++ b/.github/workflows/opencode2-real-adapter.yml
@@ -70,7 +70,7 @@ jobs:
               node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if(value.id!=="bybrawe.opencode-loop.v2.experimental" || value.activated!==true || value.commandTransform!==true || value.eventSubscribe!==true || value.sessionPrompt!==true || value.sessionCommand!==true || value.commandFieldProbe?.matched!==true) process.exit(1)' "$OPENCODE_LOOP_V2_MARKER"
               opencode2 api get /api/command -H "x-opencode-directory: $OPENCODE_LOOP_V2_PROJECT" > "$RUNNER_TEMP/opencode2-real-command-final.json"
               cat "$RUNNER_TEMP/opencode2-real-command-final.json"
-              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); for (const required of ["loop-status","loop-now","loop-export"]) if(!names.has(required)) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
+              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); for (const required of ["loop-status","loop-now","loop-export","loop-help"]) if(!names.has(required)) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
               exit 0
             fi
             sleep 0.2

--- a/scripts/v2-diagnostics-test.mjs
+++ b/scripts/v2-diagnostics-test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { createOpenCode2DiagnosticsRuntime } from "../src/source/opencode2/diagnostics.js"
+import { createOpenCode2DiagnosticsRuntime, OPENCODE_LOOP_V2_HELP_TEXT } from "../src/source/opencode2/diagnostics.js"
 
 const prompts = []
 const reads = []
@@ -35,6 +35,20 @@ assert.match(prompts[0].text, /^OpenCode loop state export:\n```json\n/)
 assert.match(prompts[0].text, /"name": "exported"/)
 assert.match(prompts[0].text, /"runCount": 2/)
 assert.match(prompts[0].text, /\n```$/)
+
+const help = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-help", sessionID: "ses", directory: "/work" })
+assert.equal(help.handled, true)
+assert.equal(help.accepted, true)
+assert.equal(reads.length, 1, "loop-help must not read or mutate Loop state")
+assert.equal(prompts.length, 2)
+assert.equal(prompts[1].noReply, true)
+assert.equal(prompts[1].text, OPENCODE_LOOP_V2_HELP_TEXT)
+assert.match(prompts[1].text, /^OpenCode Loop V2 experimental help:/)
+assert.match(prompts[1].text, /\/loop-status/)
+assert.match(prompts[1].text, /\/loop-export/)
+assert.match(prompts[1].text, /does not yet claim full stable-plugin parity/)
+assert.doesNotMatch(prompts[1].text, /\/loop-goal/)
+assert.doesNotMatch(prompts[1].text, /--verify/)
 
 assert.throws(() => createOpenCode2DiagnosticsRuntime({}), /requires prompt\(\)/)
 

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -31,6 +31,7 @@ assert.deepEqual(Object.keys(OPENCODE_LOOP_V2_COMMANDS), [
   "loop-status",
   "loop-now",
   "loop-export",
+  "loop-help",
 ])
 assert.deepEqual(
   parseOpenCode2LoopCommandText(`${OPENCODE_LOOP_V2_COMMANDS["loop-now"].template}\n\nsecond`),

--- a/src/source/opencode2/commands.js
+++ b/src/source/opencode2/commands.js
@@ -35,6 +35,10 @@ export const OPENCODE_LOOP_V2_COMMANDS = Object.freeze({
     description: "Export OpenCode Loop state for the current session.",
     template: "OpenCode Loop export command handled locally. Reply exactly: OK.",
   }),
+  "loop-help": Object.freeze({
+    description: "Show the experimental OpenCode 2 Loop command help.",
+    template: "OpenCode Loop help command handled locally. Reply exactly: OK.",
+  }),
 })
 
 export function registerOpenCode2LoopCommands(draft) {

--- a/src/source/opencode2/diagnostics.js
+++ b/src/source/opencode2/diagnostics.js
@@ -1,5 +1,19 @@
 import { readState as defaultReadState } from "../core/state.js"
 
+export const OPENCODE_LOOP_V2_HELP_TEXT = [
+  "OpenCode Loop V2 experimental help:",
+  "/loop 0s --max-runs 2 <prompt>                  autonomous prompt loop",
+  "/loop 5m --no-now --name later --multi <prompt> delayed named prompt loop",
+  "/loop 0s --command /review                       slash-command loop when the host exposes session.command",
+  "/loop-status                                      show current Loop jobs",
+  "/loop-now [target]                                run matching jobs on the next idle boundary",
+  "/loop-pause [target] | /loop-resume [target]      pause or resume jobs",
+  "/loop-stop [target] | /loop-remove [target]       remove matching jobs",
+  "/loop-clear                                       clear all jobs",
+  "/loop-export                                      export current session Loop state as JSON",
+  "Experimental V2 does not yet claim full stable-plugin parity; unsupported options fail closed.",
+].join("\n")
+
 function scopeFrom(event) {
   const directory = typeof event?.directory === "string" ? event.directory.trim() : ""
   const sessionID = String(event?.sessionID || "").trim()
@@ -21,12 +35,21 @@ export function createOpenCode2DiagnosticsRuntime(options = {}) {
     return { handled: true, accepted: true, state, request }
   }
 
+  async function help(event) {
+    const scope = scopeFrom(event)
+    if (!scope) return { handled: false, reason: "missing-scope" }
+    const request = { sessionID: scope.sessionID, text: OPENCODE_LOOP_V2_HELP_TEXT, noReply: true }
+    await options.prompt(request)
+    return { handled: true, accepted: true, request }
+  }
+
   async function onEvent(event) {
-    if (event?.kind === "command" && event?.action === "executed" && event?.name === "loop-export") {
-      return await exportState(event)
+    if (event?.kind === "command" && event?.action === "executed") {
+      if (event?.name === "loop-export") return await exportState(event)
+      if (event?.name === "loop-help") return await help(event)
     }
     return { handled: false }
   }
 
-  return Object.freeze({ onEvent, exportState })
+  return Object.freeze({ onEvent, exportState, help })
 }


### PR DESCRIPTION
## Summary
- register experimental V2 `/loop-help` through the native command transform
- serve help through the existing read-only diagnostics runtime with `noReply`
- document only the V2 behaviors currently implemented; do not advertise stable-only goal/verify/checkpoint features
- explicitly state that experimental V2 does not yet claim full stable-plugin parity
- cover help output deterministically and require `loop-help` in the real `@next` command registry

## Safety
Read-only diagnostics only. No Loop state mutation, scheduler behavior, dispatch policy, or V2 readiness flag changes.