### PR TITLE
feat(v2): add read-only loop-doctor parity

### DIFF
--- a/.github/workflows/opencode2-real-adapter.yml
+++ b/.github/workflows/opencode2-real-adapter.yml
@@ -70,7 +70,7 @@ jobs:
               node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if(value.id!=="bybrawe.opencode-loop.v2.experimental" || value.activated!==true || value.commandTransform!==true || value.eventSubscribe!==true || value.sessionPrompt!==true || value.sessionCommand!==true || value.commandFieldProbe?.matched!==true) process.exit(1)' "$OPENCODE_LOOP_V2_MARKER"
               opencode2 api get /api/command -H "x-opencode-directory: $OPENCODE_LOOP_V2_PROJECT" > "$RUNNER_TEMP/opencode2-real-command-final.json"
               cat "$RUNNER_TEMP/opencode2-real-command-final.json"
-              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); for (const required of ["loop-status","loop-now","loop-export","loop-help"]) if(!names.has(required)) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
+              node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); const data=Array.isArray(value?.data)?value.data:Array.isArray(value)?value:[]; const names=new Set(data.map((item)=>item?.name)); for (const required of ["loop-status","loop-now","loop-export","loop-help","loop-doctor"]) if(!names.has(required)) process.exit(1)' "$RUNNER_TEMP/opencode2-real-command-final.json"
               exit 0
             fi
             sleep 0.2

--- a/scripts/v2-diagnostics-test.mjs
+++ b/scripts/v2-diagnostics-test.mjs
@@ -13,6 +13,8 @@ const runtime = createOpenCode2DiagnosticsRuntime({
     reads.push([directory, sessionID])
     return structuredClone(state)
   },
+  runtimeVersion: "v-test",
+  runtimePlatform: "test-platform",
 })
 
 const unrelated = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-status", sessionID: "ses", directory: "/work" })
@@ -46,9 +48,26 @@ assert.equal(prompts[1].text, OPENCODE_LOOP_V2_HELP_TEXT)
 assert.match(prompts[1].text, /^OpenCode Loop V2 experimental help:/)
 assert.match(prompts[1].text, /\/loop-status/)
 assert.match(prompts[1].text, /\/loop-export/)
+assert.match(prompts[1].text, /\/loop-doctor/)
 assert.match(prompts[1].text, /does not yet claim full stable-plugin parity/)
 assert.doesNotMatch(prompts[1].text, /\/loop-goal/)
 assert.doesNotMatch(prompts[1].text, /--verify/)
+
+const doctor = await runtime.onEvent({ kind: "command", action: "executed", name: "loop-doctor", sessionID: "ses", directory: "/work" })
+assert.equal(doctor.handled, true)
+assert.equal(doctor.accepted, true)
+assert.equal(reads.length, 2, "loop-doctor may read state but must not mutate it")
+assert.equal(prompts.length, 3)
+assert.equal(prompts[2].noReply, true)
+assert.match(prompts[2].text, /^OpenCode Loop V2 doctor:/)
+assert.match(prompts[2].text, /- plugin: bybrawe\.opencode-loop\.v2\.experimental/)
+assert.match(prompts[2].text, /- project directory: \/work/)
+assert.match(prompts[2].text, /- state directory:/)
+assert.match(prompts[2].text, /- active jobs: 1/)
+assert.match(prompts[2].text, /- node: v-test/)
+assert.match(prompts[2].text, /- platform: test-platform/)
+assert.match(prompts[2].text, /- full stable parity: not claimed/)
+assert.match(prompts[2].text, /- smoke test: \/loop 0s --max-runs 1/)
 
 assert.throws(() => createOpenCode2DiagnosticsRuntime({}), /requires prompt\(\)/)
 

--- a/scripts/v2-plugin-sentinel-test.mjs
+++ b/scripts/v2-plugin-sentinel-test.mjs
@@ -32,6 +32,7 @@ assert.deepEqual(Object.keys(OPENCODE_LOOP_V2_COMMANDS), [
   "loop-now",
   "loop-export",
   "loop-help",
+  "loop-doctor",
 ])
 assert.deepEqual(
   parseOpenCode2LoopCommandText(`${OPENCODE_LOOP_V2_COMMANDS["loop-now"].template}\n\nsecond`),

--- a/src/source/opencode2/commands.js
+++ b/src/source/opencode2/commands.js
@@ -39,6 +39,10 @@ export const OPENCODE_LOOP_V2_COMMANDS = Object.freeze({
     description: "Show the experimental OpenCode 2 Loop command help.",
     template: "OpenCode Loop help command handled locally. Reply exactly: OK.",
   }),
+  "loop-doctor": Object.freeze({
+    description: "Show experimental OpenCode 2 Loop diagnostics.",
+    template: "OpenCode Loop doctor command handled locally. Reply exactly: OK.",
+  }),
 })
 
 export function registerOpenCode2LoopCommands(draft) {

--- a/src/source/opencode2/diagnostics.js
+++ b/src/source/opencode2/diagnostics.js
@@ -1,4 +1,4 @@
-import { readState as defaultReadState } from "../core/state.js"
+import { readState as defaultReadState, stateDir } from "../core/state.js"
 
 export const OPENCODE_LOOP_V2_HELP_TEXT = [
   "OpenCode Loop V2 experimental help:",
@@ -11,6 +11,8 @@ export const OPENCODE_LOOP_V2_HELP_TEXT = [
   "/loop-stop [target] | /loop-remove [target]       remove matching jobs",
   "/loop-clear                                       clear all jobs",
   "/loop-export                                      export current session Loop state as JSON",
+  "/loop-help                                        show this experimental V2 help",
+  "/loop-doctor                                      show local V2 diagnostics",
   "Experimental V2 does not yet claim full stable-plugin parity; unsupported options fail closed.",
 ].join("\n")
 
@@ -24,6 +26,8 @@ function scopeFrom(event) {
 export function createOpenCode2DiagnosticsRuntime(options = {}) {
   if (typeof options.prompt !== "function") throw new TypeError("V2 diagnostics runtime requires prompt()")
   const readState = typeof options.readState === "function" ? options.readState : defaultReadState
+  const runtimeVersion = options.runtimeVersion || process.version
+  const runtimePlatform = options.runtimePlatform || process.platform
 
   async function exportState(event) {
     const scope = scopeFrom(event)
@@ -43,13 +47,34 @@ export function createOpenCode2DiagnosticsRuntime(options = {}) {
     return { handled: true, accepted: true, request }
   }
 
+  async function doctor(event) {
+    const scope = scopeFrom(event)
+    if (!scope) return { handled: false, reason: "missing-scope" }
+    const state = await readState(scope.directory, scope.sessionID)
+    const text = [
+      "OpenCode Loop V2 doctor:",
+      "- plugin: bybrawe.opencode-loop.v2.experimental",
+      `- project directory: ${scope.directory}`,
+      `- state directory: ${stateDir(scope.directory)}`,
+      `- active jobs: ${(state.jobs || []).length}`,
+      `- node: ${runtimeVersion}`,
+      `- platform: ${runtimePlatform}`,
+      "- full stable parity: not claimed",
+      "- smoke test: /loop 0s --max-runs 1 continue the current task",
+    ].join("\n")
+    const request = { sessionID: scope.sessionID, text, noReply: true }
+    await options.prompt(request)
+    return { handled: true, accepted: true, state, request }
+  }
+
   async function onEvent(event) {
     if (event?.kind === "command" && event?.action === "executed") {
       if (event?.name === "loop-export") return await exportState(event)
       if (event?.name === "loop-help") return await help(event)
+      if (event?.name === "loop-doctor") return await doctor(event)
     }
     return { handled: false }
   }
 
-  return Object.freeze({ onEvent, exportState, help })
+  return Object.freeze({ onEvent, exportState, help, doctor })
 }


### PR DESCRIPTION
## Summary
- register experimental V2 `/loop-doctor`
- report project directory, state directory, active job count, Node version, platform, and parity status through the read-only diagnostics runtime
- include a conservative one-shot smoke test without advertising unsupported stable-only options
- extend deterministic diagnostics coverage and require `loop-doctor` in the real `@next` command registry

## Safety
Read-only diagnostics only. Doctor reads the current session state but does not write state, schedule work, or change the experimental V2 readiness flag.