### PR TITLE
chore: finalize 0.5.31 release metadata

### DIFF
--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,0 +1,4 @@
+- Add best-effort experimental OpenCode 2 runtime logging in the existing JSON-lines `loop.log` format, tagged with `v2: true`, plus experimental `/loop-logs` diagnostics for recent V2 records. Logging remains non-critical and does not change the stable OpenCode 1.x support claim.
+- Keep an already-installed `@bybrawe/opencode-goal` companion current when Loop is installed/updated by delegating to Goals' own `@latest` installer. Add `--with-goals` for an explicit combined install and `--loop-only` to suppress companion network work; Loop uninstall never removes Goals.
+- Add deterministic cross-platform companion-installer coverage for package/local/managed-command detection, JSONC comment false positives, opt-out, explicit failure semantics, help output, and best-effort automatic refresh behavior.
+- Keep release metadata internally consistent by synchronizing the package-lock root `bin` map with `package.json` while preparing releases.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,4 +1,0 @@
-- Add best-effort experimental OpenCode 2 runtime logging in the existing JSON-lines `loop.log` format, tagged with `v2: true`, plus experimental `/loop-logs` diagnostics for recent V2 records. Logging remains non-critical and does not change the stable OpenCode 1.x support claim.
-- Keep an already-installed `@bybrawe/opencode-goal` companion current when Loop is installed/updated by delegating to Goals' own `@latest` installer. Add `--with-goals` for an explicit combined install and `--loop-only` to suppress companion network work; Loop uninstall never removes Goals.
-- Add deterministic cross-platform companion-installer coverage for package/local/managed-command detection, JSONC comment false positives, opt-out, explicit failure semantics, help output, and best-effort automatic refresh behavior.
-- Keep release metadata internally consistent by synchronizing the package-lock root `bin` map with `package.json` while preparing releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.31
+
+- Add best-effort experimental OpenCode 2 runtime logging in the existing JSON-lines `loop.log` format, tagged with `v2: true`, plus experimental `/loop-logs` diagnostics for recent V2 records. Logging remains non-critical and does not change the stable OpenCode 1.x support claim.
+- Keep an already-installed `@bybrawe/opencode-goal` companion current when Loop is installed/updated by delegating to Goals' own `@latest` installer. Add `--with-goals` for an explicit combined install and `--loop-only` to suppress companion network work; Loop uninstall never removes Goals.
+- Add deterministic cross-platform companion-installer coverage for package/local/managed-command detection, JSONC comment false positives, opt-out, explicit failure semantics, help output, and best-effort automatic refresh behavior.
+- Keep release metadata internally consistent by synchronizing the package-lock root `bin` map with `package.json` while preparing releases.
+
 ## 0.5.30
 
 - Harden npm publishing so a one-shot release publishes the immutable trigger SHA, verifies that commit belongs to `main`, serializes releases, confirms the package is readable from npm, and tags exactly the published snapshot.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 OpenCode Loop adds `/loop`, scheduled prompt/command/shell jobs, compact scheduling, safe long-running continuation helpers, and the `opencode-loopd` background daemon.
 
-> **Current release: `0.5.30`.** Loop also contains an older experimental `/loop-goal` mode, but for strong persistent Goal contracts and host-verified completion, use the separate **OpenCode Goals** plugin described below.
+> **Current release: `0.5.31`.** Loop also contains an older experimental `/loop-goal` mode, but for strong persistent Goal contracts and host-verified completion, use the separate **OpenCode Goals** plugin described below.
 
 ## Install or update
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bybrawe/opencode-loop",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bybrawe/opencode-loop",
-      "version": "0.5.30",
+      "version": "0.5.31",
       "license": "MIT",
       "bin": {
-        "opencode-loop": "scripts/install-node.mjs",
+        "opencode-loop": "scripts/install-with-goals.mjs",
         "opencode-loopd": "scripts/loopd.mjs"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bybrawe/opencode-loop",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "Claude Code/Codex style /loop and experimental goal mode for OpenCode: heartbeat scheduler, idle-safe loops, scheduled commands, compact scheduling, verification, checkpoints, and persistent coding goals.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## 0.5.31

Finalize release metadata after the V2 logging and OpenCode Goals companion-updater work landed on `main`.

- bump package and lock metadata to 0.5.31;
- sync package-lock root `bin` metadata to the new `scripts/install-with-goals.mjs` entrypoint;
- update README current release marker;
- add 0.5.31 changelog notes covering experimental V2 logging/`/loop-logs`, automatic refresh of an already-installed Goals companion, `--with-goals`, `--loop-only`, and cross-platform installer coverage.

No runtime/domain code is changed by this PR.