### PR TITLE
fix: reduce Loop command clutter with Goals

### DIFF
--- a/agents/opencode-loop-local.md
+++ b/agents/opencode-loop-local.md
@@ -1,6 +1,7 @@
 ---
 description: Handles OpenCode Loop slash-command acknowledgements without tools.
-mode: primary
+mode: subagent
+hidden: true
 permission:
   "*": deny
 ---

--- a/scripts/goal-companion-test.mjs
+++ b/scripts/goal-companion-test.mjs
@@ -62,6 +62,20 @@ async function calls(log) {
   }
 }
 
+async function loopGoalCommands(config) {
+  try {
+    return (await fs.readdir(path.join(config, "commands")))
+      .filter((name) => name === "loop-goal.md" || (name.startsWith("loop-goal-") && name.endsWith(".md")))
+  } catch (error) {
+    if (error?.code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function exists(target) {
+  try { await fs.access(target); return true } catch { return false }
+}
+
 async function writeConfig(config, plugins, comment = "") {
   await fs.mkdir(config, { recursive: true })
   await fs.writeFile(
@@ -71,12 +85,26 @@ async function writeConfig(config, plugins, comment = "") {
   )
 }
 
+const localAgent = await fs.readFile(path.join(root, "agents", "opencode-loop-local.md"), "utf8")
+assert.match(localAgent, /^mode:\s*subagent$/m, "the local acknowledgement agent must not participate in the primary-agent cycle")
+assert.match(localAgent, /^hidden:\s*true$/m, "the local acknowledgement agent must be hidden from normal subagent selection")
+
 try {
   const absentConfig = path.join(temporaryRoot, "absent")
   const absentLog = path.join(temporaryRoot, "absent.log")
   const absent = await runInstaller(absentConfig, [], { FAKE_NPM_LOG: absentLog })
   assert.equal(absent.code, 0, absent.stderr)
   assert.deepEqual(await calls(absentLog), [], "Loop-only installations must not silently add Goals")
+  assert.ok((await loopGoalCommands(absentConfig)).length > 0, "legacy Loop Goal commands stay installed by default for compatibility")
+
+  const withoutLoopGoalsConfig = path.join(temporaryRoot, "without-loop-goals")
+  const withoutLoopGoalsLog = path.join(temporaryRoot, "without-loop-goals.log")
+  const withoutLoopGoals = await runInstaller(withoutLoopGoalsConfig, ["--without-loop-goals"], { FAKE_NPM_LOG: withoutLoopGoalsLog })
+  assert.equal(withoutLoopGoals.code, 0, withoutLoopGoals.stderr)
+  assert.deepEqual(await calls(withoutLoopGoalsLog), [], "omitting legacy Loop Goal commands must not silently install Goals")
+  assert.deepEqual(await loopGoalCommands(withoutLoopGoalsConfig), [], "--without-loop-goals must remove every packaged experimental /loop-goal* command")
+  assert.equal(await exists(path.join(withoutLoopGoalsConfig, "commands", "loop.md")), true, "normal Loop commands must remain installed")
+  assert.match(withoutLoopGoals.stdout, /Omitted \d+ packaged experimental \/loop-goal\*/)
 
   const existingConfig = path.join(temporaryRoot, "existing")
   const existingLog = path.join(temporaryRoot, "existing.log")
@@ -114,6 +142,13 @@ try {
   assert.equal(explicit.code, 0, explicit.stderr)
   assert.deepEqual(await calls(explicitLog), [expectedGoalExec], "--with-goals must install the companion even when it is absent")
 
+  const explicitCleanConfig = path.join(temporaryRoot, "explicit-clean")
+  const explicitCleanLog = path.join(temporaryRoot, "explicit-clean.log")
+  const explicitClean = await runInstaller(explicitCleanConfig, ["--with-goals", "--without-loop-goals"], { FAKE_NPM_LOG: explicitCleanLog })
+  assert.equal(explicitClean.code, 0, explicitClean.stderr)
+  assert.deepEqual(await calls(explicitCleanLog), [expectedGoalExec], "the clean command surface option must compose with --with-goals")
+  assert.deepEqual(await loopGoalCommands(explicitCleanConfig), [], "combined install must keep the stronger Goals plugin without legacy Loop Goal command clutter")
+
   const optOutConfig = path.join(temporaryRoot, "opt-out")
   const optOutLog = path.join(temporaryRoot, "opt-out.log")
   await writeConfig(optOutConfig, ["@bybrawe/opencode-goal@1.3.16"])
@@ -146,6 +181,7 @@ try {
   assert.match(help.stdout, /OpenCode Loop installer\/updater/)
   assert.match(help.stdout, /--with-goals/)
   assert.match(help.stdout, /--loop-only/)
+  assert.match(help.stdout, /--without-loop-goals/)
   assert.match(help.stdout, /Loop uninstall never removes Goals/)
   assert.deepEqual(await calls(helpLog), [], "help/version flows must never install companion packages")
 

--- a/scripts/install-with-goals.mjs
+++ b/scripts/install-with-goals.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process"
-import { readFile } from "node:fs/promises"
+import { readFile, readdir, rm } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import process from "node:process"
@@ -16,7 +16,8 @@ const managedGoalCommandMarker = "<!-- managed-by:@bybrawe/opencode-goal -->"
 const rawArgs = process.argv.slice(2)
 const withGoals = rawArgs.includes("--with-goals")
 const loopOnly = rawArgs.includes("--loop-only")
-const loopArgs = rawArgs.filter((arg) => arg !== "--with-goals" && arg !== "--loop-only")
+const withoutLoopGoals = rawArgs.includes("--without-loop-goals")
+const loopArgs = rawArgs.filter((arg) => !["--with-goals", "--loop-only", "--without-loop-goals"].includes(arg))
 const uninstallRequested = loopArgs.length === 1 && ["--uninstall", "uninstall", "--remove"].includes(loopArgs[0] || "")
 const helpRequested = loopArgs.some((arg) => ["--help", "-h"].includes(arg))
 const versionRequested = loopArgs.some((arg) => ["--version", "-v"].includes(arg))
@@ -117,6 +118,22 @@ async function goalsAlreadyInstalled() {
   return false
 }
 
+async function removeLoopGoalCommands() {
+  const commandDir = join(config, "commands")
+  const names = (await readdir(join(root, "commands")))
+    .filter((name) => name === "loop-goal.md" || (name.startsWith("loop-goal-") && name.endsWith(".md")))
+  let removed = 0
+  for (const name of names) {
+    try {
+      await rm(join(commandDir, name))
+      removed++
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error
+    }
+  }
+  return removed
+}
+
 function runLoopInstaller() {
   return spawnSync(process.execPath, [loopInstaller, ...loopArgs], {
     cwd: root,
@@ -148,7 +165,7 @@ function statusCode(result) {
 }
 
 function printCompanionHelp() {
-  console.log(`\nOpenCode Goals companion options:\n  --with-goals  Install/update @bybrawe/opencode-goal@latest even when it is not already installed.\n  --loop-only   Skip all OpenCode Goals companion detection and network update work.\n\nNormal Loop install/update refreshes an already-managed OpenCode Goals installation on a best-effort basis. Loop uninstall never removes Goals.`)
+  console.log(`\nOpenCode Goals companion options:\n  --with-goals          Install/update @bybrawe/opencode-goal@latest even when it is not already installed.\n  --loop-only           Skip all OpenCode Goals companion detection and network update work.\n  --without-loop-goals  Omit/remove Loop's packaged experimental /loop-goal* command files for this install/update.\n\nNormal Loop install/update refreshes an already-managed OpenCode Goals installation on a best-effort basis. Loop uninstall never removes Goals.`)
 }
 
 async function main() {
@@ -175,6 +192,11 @@ async function main() {
     return
   }
   if (uninstallRequested) return
+
+  if (withoutLoopGoals) {
+    const removed = await removeLoopGoalCommands()
+    console.log(`Omitted ${removed} packaged experimental /loop-goal* command file(s) (--without-loop-goals).`)
+  }
 
   if (loopOnly) {
     console.log("Skipped OpenCode Goals companion update (--loop-only).")


### PR DESCRIPTION
## Summary

- hide the tool-denied `opencode-loop-local` acknowledgement agent from the normal primary-agent cycle by making it a hidden subagent while keeping slash commands explicitly bound to it
- add `--without-loop-goals` to the Loop installer wrapper so users can omit/remove packaged experimental `/loop-goal*` commands without touching normal Loop commands or the separate OpenCode Goals plugin
- keep default behavior backward-compatible: legacy `/loop-goal*` commands remain installed unless the new flag is requested
- cover the flag together with `--with-goals`, plus deterministic hidden-agent assertions

Closes #126
Closes #127