### PR TITLE
Monitor latest Goal coexistence on a schedule

### DIFF
--- a/.github/workflows/goal-coexistence-latest.yml
+++ b/.github/workflows/goal-coexistence-latest.yml
@@ -1,0 +1,57 @@
+name: Latest Goal Coexistence Canary
+
+on:
+  schedule:
+    - cron: "43 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: latest-goal-coexistence
+  cancel-in-progress: true
+
+jobs:
+  latest-companion:
+    name: Loop main + Goal latest (${{ matrix.os }})
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: npm ci
+
+      - name: Install moving compatibility targets
+        run: npm install --no-save --package-lock=false opencode-ai@latest @bybrawe/opencode-goal@latest
+
+      - name: Show tested versions
+        run: |
+          node -p "require('./package.json').version"
+          npx --no-install opencode --version
+          node -p "require('./node_modules/@bybrawe/opencode-goal/package.json').version"
+
+      - name: Check coexistence canary syntax
+        run: node --check scripts/host-goal-coexistence-canary.mjs
+
+      - name: Require one autonomous owner with latest Goal
+        run: node scripts/host-goal-coexistence-canary.mjs
+        env:
+          OPENCODE_PRINT_LOGS: "1"
+          OPENCODE_LOG_LEVEL: DEBUG


### PR DESCRIPTION
## Goal
Detect future cross-plugin ownership regressions without making ordinary Loop pull requests depend on a moving companion release.

## Change
Adds a separate scheduled/manual real-host canary that runs Loop main against:
- `@bybrawe/opencode-goal@latest`
- `opencode-ai@latest`
- Ubuntu and Windows

It reuses the permanent coexistence canary merged in #144 and requires the single-autonomous-owner contract to hold.

The normal PR coexistence gate remains pinned to Goal 1.3.27 for deterministic CI. This moving-`latest` workflow runs daily and can also be dispatched manually.

No production Loop behavior or package contents are changed.