### PR TITLE
Release OpenCode Loop 0.5.36

### DIFF
--- a/.github/workflows/prepare-release-metadata.yml
+++ b/.github/workflows/prepare-release-metadata.yml
@@ -56,9 +56,12 @@ jobs:
 
           const readmePath = "README.md"
           const readme = fs.readFileSync(readmePath, "utf8")
-          const marker = /\*\*Current release: `[^`]+`\.\*\*/
-          if (!marker.test(readme)) throw new Error("README current release marker not found")
-          fs.writeFileSync(readmePath, readme.replace(marker, `**Current release: \`${version}\`.**`))
+          const marker = /((?:>\s*)?)\*\*Current(?: stable)? release: `[^`]+`\.\*\*/
+          if (!marker.test(readme)) throw new Error("README current stable release marker not found")
+          fs.writeFileSync(
+            readmePath,
+            readme.replace(marker, (_match, prefix = "") => `${prefix}**Current stable release: \`${version}\`.**`),
+          )
           NODE
 
       - name: Prepend changelog notes

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,9 +1,0 @@
-Empty-turn fail-safe release.
-
-- Distinguish a completed assistant message from a meaningful completed Loop turn instead of treating a timestamp-only blank reply as success.
-- Count non-empty assistant text and tool/file/patch/artifact activity anywhere in the logical run as meaningful work, including tool-only runs with a blank final assistant tail.
-- Refund a completed-but-empty logical run so it does not consume `runCount`, `--max-runs`, or normal success finalization/checkpoint behavior.
-- Persist consecutive empty-turn state across reloads, retry one empty completion with bounded delay, then pause safely after the second consecutive empty turn with a visible warning instead of injecting prompts forever.
-- Recover stale host `busy` state for already-completed empty turns so the fail-safe can finalize them rather than leaving the Loop stuck between busy and due states.
-- Keep release metadata automation compatible with the README's `Current stable release` marker so future release prep does not fail on the documented format.
-- Add focused regressions for blank/whitespace replies, tool activity, max-run refund/re-enable, bounded retry, fail-safe pause, successful streak reset, and generated-bundle parity; full Ubuntu/Windows CI, real-host, Goal coexistence, lifecycle, and single-file bundle gates are green on the feature head.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -5,4 +5,5 @@ Empty-turn fail-safe release.
 - Refund a completed-but-empty logical run so it does not consume `runCount`, `--max-runs`, or normal success finalization/checkpoint behavior.
 - Persist consecutive empty-turn state across reloads, retry one empty completion with bounded delay, then pause safely after the second consecutive empty turn with a visible warning instead of injecting prompts forever.
 - Recover stale host `busy` state for already-completed empty turns so the fail-safe can finalize them rather than leaving the Loop stuck between busy and due states.
+- Keep release metadata automation compatible with the README's `Current stable release` marker so future release prep does not fail on the documented format.
 - Add focused regressions for blank/whitespace replies, tool activity, max-run refund/re-enable, bounded retry, fail-safe pause, successful streak reset, and generated-bundle parity; full Ubuntu/Windows CI, real-host, Goal coexistence, lifecycle, and single-file bundle gates are green on the feature head.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,0 +1,8 @@
+Empty-turn fail-safe release.
+
+- Distinguish a completed assistant message from a meaningful completed Loop turn instead of treating a timestamp-only blank reply as success.
+- Count non-empty assistant text and tool/file/patch/artifact activity anywhere in the logical run as meaningful work, including tool-only runs with a blank final assistant tail.
+- Refund a completed-but-empty logical run so it does not consume `runCount`, `--max-runs`, or normal success finalization/checkpoint behavior.
+- Persist consecutive empty-turn state across reloads, retry one empty completion with bounded delay, then pause safely after the second consecutive empty turn with a visible warning instead of injecting prompts forever.
+- Recover stale host `busy` state for already-completed empty turns so the fail-safe can finalize them rather than leaving the Loop stuck between busy and due states.
+- Add focused regressions for blank/whitespace replies, tool activity, max-run refund/re-enable, bounded retry, fail-safe pause, successful streak reset, and generated-bundle parity; full Ubuntu/Windows CI, real-host, Goal coexistence, lifecycle, and single-file bundle gates are green on the feature head.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.36
+
+Empty-turn fail-safe release.
+
+- Distinguish a completed assistant message from a meaningful completed Loop turn instead of treating a timestamp-only blank reply as success.
+- Count non-empty assistant text and tool/file/patch/artifact activity anywhere in the logical run as meaningful work, including tool-only runs with a blank final assistant tail.
+- Refund a completed-but-empty logical run so it does not consume `runCount`, `--max-runs`, or normal success finalization/checkpoint behavior.
+- Persist consecutive empty-turn state across reloads, retry one empty completion with bounded delay, then pause safely after the second consecutive empty turn with a visible warning instead of injecting prompts forever.
+- Recover stale host `busy` state for already-completed empty turns so the fail-safe can finalize them rather than leaving the Loop stuck between busy and due states.
+- Keep release metadata automation compatible with the README's `Current stable release` marker so future release prep does not fail on the documented format.
+- Add focused regressions for blank/whitespace replies, tool activity, max-run refund/re-enable, bounded retry, fail-safe pause, successful streak reset, and generated-bundle parity; full Ubuntu/Windows CI, real-host, Goal coexistence, lifecycle, and single-file bundle gates are green on the feature head.
+
 ## 0.5.35
 
 - Treat OpenCode `session.status=retry` as authoritative provider ownership: retry and unreadable status can no longer age into idle and cause an overlapping Loop turn; a genuinely completed current assistant message can still release stale retry safely.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 OpenCode Loop adds `/loop`, scheduled prompt/command/shell jobs, compact scheduling, verification/checkpoints, and the `opencode-loopd` background daemon.
 
-> **Current stable release: `0.5.35`.**
+> **Current stable release: `0.5.36`.**
 
 ## Install or update
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bybrawe/opencode-loop",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bybrawe/opencode-loop",
-      "version": "0.5.35",
+      "version": "0.5.36",
       "license": "MIT",
       "bin": {
         "opencode-loop": "scripts/install-with-goals.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bybrawe/opencode-loop",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "description": "Claude Code/Codex style /loop and experimental goal mode for OpenCode: heartbeat scheduler, idle-safe loops, scheduled commands, compact scheduling, verification, checkpoints, and persistent coding goals.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## OpenCode Loop 0.5.36

Release the empty-turn fail-safe fix merged in #146.

### Runtime reliability
- Completed assistant messages are no longer automatically treated as meaningful successful Loop iterations.
- Blank completed prompt/goal turns are refunded instead of consuming logical runs or `--max-runs` slots.
- One empty turn gets a bounded retry; a second consecutive empty completion pauses safely with a visible warning rather than creating an infinite continuation churn.
- Text/tool/file/patch/artifact activity anywhere in the logical run counts as meaningful work, preserving tool-only runs whose final assistant tail is blank.
- Stale host `busy` state can settle already-completed empty turns so the fail-safe can run.

### Release tooling
- Update package/package-lock/README/CHANGELOG to 0.5.36.
- Fix release metadata automation to recognize the README's existing `Current stable release` marker so future release prep remains compatible with the documented format.

### Validation
Feature head passed exact-head CI on Ubuntu/Windows, OpenCode plugin compatibility 1.4.0/latest, real OpenCode host canaries on Ubuntu/Windows, V2 lifecycle contracts, Dedicated Goal coexistence, and the single-file generated bundle gate on Ubuntu/Windows.